### PR TITLE
RFC: Join/Quit/Kick membership synchronisation, GET /chat/events API, and MX->MC kicks & bans

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -24,6 +24,79 @@ The response body returns an array of pre-formatted messages like
 |-----------|----------|----------------------------------------------------------------------------|
 | chat      | string[] | An array of pre-formatted messages ready to be sent to the Minecraft chat. |
 
+### GET /events
+
+#### Required Headers:
+The provided JSON web token describes what room the server is bridged with.
+ - Content-Type: `application/json`
+ - Authorization: `Bearer <JSON WEB TOKEN>`
+
+#### Request Body
+None
+
+#### Response Body:
+The response body returns an array of structured events.
+
+| Attribute | Type      | Description                                                       |
+|-----------|-----------|-------------------------------------------------------------------|
+| events    | MxEvent[] | An array of structured events for the Minecraft plugin to handle. |
+
+##### MxEvent Object:
+This describes the Matrix event. It must have at least the following fields,
+but may have more depending on the type:
+
+| Attribute | Type   | Description                     |
+|-----------|--------|---------------------------------|
+| sender    | MxUser | The Matrix sender of the event. |
+| type      | string | An event type identifier.       |
+
+##### MxUser Object:
+This describes a Matrix user, allowing the Minecraft plugin to format it as it
+likes, for example showing the displayName but with the MXID in a tooltip.
+
+| Attribute   | Type   | Description                  |
+|-------------|--------|------------------------------|
+| mxid        | string | Matrix ID of user.           |
+| displayName | string | The displayName of the user. |
+
+##### message.text Event:
+This describes a normal text message send by the Matrix sender user. It extends
+the MxEvent object with the following additional fields:
+
+| Attribute | Type   | Description             |
+|-----------|--------|-------------------------|
+| type      | string | must be "message.text". |
+| body      | string | The message itself.     |
+
+The Minecraft plugin is expected to broadcast the message, prefixing the body
+with the name of the sender.
+
+##### message.emote Event:
+This describes an emote message send by the Matrix sender user (e.g. with
+"/me").
+It extends the MxEvent object with the following additional fields:
+
+| Attribute | Type   | Description              |
+|-----------|--------|--------------------------|
+| type      | string | must be "message.emote". |
+| body      | string | The message itself.      |
+
+The Minecraft plugin is expected to broadcast the message, prefixing the body
+with e.g. "\*" and the name of the sender.
+
+##### message.announce Event:
+This describes an announcement message send by a sufficiently privileged Matrix
+sender user (i.e. with "!minecraft announce").
+It extends the MxEvent object with the following additional fields:
+
+| Attribute | Type   | Description                 |
+|-----------|--------|-----------------------------|
+| type      | string | must be "message.announce". |
+| body      | string | The message itself.         |
+
+The Minecraft plugin is expected to broadcast the message as if send from the
+Minecraft server console, e.g. prefixing the body with "[Server] ".
+
 ### POST /chat
 This endpoint is for sending a Minecraft chat message to the bridged Matrix
  room.

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -97,6 +97,44 @@ It extends the MxEvent object with the following additional fields:
 The Minecraft plugin is expected to broadcast the message as if send from the
 Minecraft server console, e.g. prefixing the body with "[Server] ".
 
+##### player.kick Event:
+This describes the kicking of a Minecraft user from the Matrix room.
+It extends the MxEvent object with the following additional fields:
+
+| Attribute | Type   | Description                      |
+|-----------|--------|----------------------------------|
+| type      | string | must be "player.kick".           |
+| player    | Player | The player who was kicked.       |
+| reason    | string | Optional reason for the kicking. |
+
+The Minecraft plugin may respond to this event by kicking the player from the
+server too.
+
+##### player.ban Event:
+This describes the banning of a Minecraft user from the Matrix room.
+It extends the MxEvent object with the following additional fields:
+
+| Attribute | Type   | Description                      |
+|-----------|--------|----------------------------------|
+| type      | string | must be "player.ban".            |
+| player    | Player | The player who was banned.       |
+| reason    | string | Optional reason for the banning. |
+
+The Minecraft plugin may respond to this event by banning the player from the
+server too.
+
+##### player.unban Event:
+This describes the unbanning of a Minecraft user from the Matrix room.
+It extends the MxEvent object with the following additional fields:
+
+| Attribute | Type   | Description                  |
+|-----------|--------|------------------------------|
+| type      | string | must be "player.unban".      |
+| player    | Player | The player who was unbanned. |
+
+The Minecraft plugin may respond to this event by unbanning the player from the
+server too.
+
 ### POST /chat
 This endpoint is for sending a Minecraft chat message to the bridged Matrix
  room.

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -50,3 +50,52 @@ be null or undefined.
 
 #### Response Body:
 None (200 OK)
+
+### POST /player/join
+This endpoint is for joining a Minecraft player to the bridged Matrix room.
+
+#### Required Headers:
+The provided JSON web token describes what room the server is bridged with.
+ - Content-Type: `application/json`
+ - Authorization: `Bearer <JSON WEB TOKEN>`
+
+#### Request Body:
+| Attribute | Type   | Description                           |
+|-----------|--------|---------------------------------------|
+| player    | Player | The player who joined                 |
+
+#### Response Body:
+None (200 OK)
+
+### POST /player/quit
+This endpoint is for making a Minecraft player leave the bridged Matrix room.
+
+#### Required Headers:
+The provided JSON web token describes what room the server is bridged with.
+ - Content-Type: `application/json`
+ - Authorization: `Bearer <JSON WEB TOKEN>`
+
+#### Request Body:
+| Attribute | Type   | Description                           |
+|-----------|--------|---------------------------------------|
+| player    | Player | The player who quit                   |
+
+#### Response Body:
+None (200 OK)
+
+### POST /player/kick
+This endpoint is for kicking a Minecraft player from the bridged Matrix room.
+
+#### Required Headers:
+The provided JSON web token describes what room the server is bridged with.
+ - Content-Type: `application/json`
+ - Authorization: `Bearer <JSON WEB TOKEN>`
+
+#### Request Body:
+| Attribute | Type   | Description                           |
+|-----------|--------|---------------------------------------|
+| reason    | string | The kick reason                       |
+| player    | Player | The player who was kicked             |
+
+#### Response Body:
+None (200 OK)

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -3,7 +3,7 @@ import { Config } from "./Config";
 import { Bridge, BridgeManager } from "./bridging";
 import { MatrixInterface } from "./matrix";
 import { DBController } from "./db";
-import { MCEvents, PlayerManager } from "./minecraft";
+import { MxEvents, MCEvents, PlayerManager } from "./minecraft";
 import { MxMessage } from "./matrix/MatrixInterface";
 
 
@@ -71,9 +71,9 @@ export class Main {
    * This gets all the new messages from a bridged Matrix room
    * Minecraft (GET Request)  ->           WebInterface
    * Minecraft (GET Response) <- string[]  WebInterface
-   * @returns {string[]}
+   * @returns {MxEvents.Event[]}
    */
-  public getNewMxMessages(bridge: Bridge): string[] {
+  public getNewMxMessages(bridge: Bridge): MxEvents.Event[] {
     return this.matrix.getNewMxMessages(bridge);
   }
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -90,4 +90,46 @@ export class Main {
   public sendToMatrix(bridge: Bridge, message: MCEvents.Message) {
     return this.matrix.sendMessage(bridge, message);
   }
+
+  /**
+   * This handles Minecraft join events provided by a Minecraft server
+   * Minecraft (POST Request) Player join event ->        WebInterface
+   * Minecraft (POST Response)                  <- 200 OK WebInterface
+   *
+   * @param {Bridge} bridge Bridged room
+   * @param {MCEvents.Join} join Join event to send
+   * @returns {Promise<void>}
+   * @throws {NotBridgedError}
+   */
+  public joinToMatrix(bridge: Bridge, join: MCEvents.Join) {
+    return this.matrix.sendJoin(bridge, join);
+  }
+
+  /**
+   * This handles Minecraft quit events provided by a Minecraft server
+   * Minecraft (POST Request) Player quit event ->        WebInterface
+   * Minecraft (POST Response)                  <- 200 OK WebInterface
+   *
+   * @param {Bridge} bridge Bridged room
+   * @param {MCEvents.Quit} quit Quit event to send
+   * @returns {Promise<void>}
+   * @throws {NotBridgedError}
+   */
+  public quitToMatrix(bridge: Bridge, quit: MCEvents.Quit) {
+    return this.matrix.sendQuit(bridge, quit);
+  }
+
+  /**
+   * This handles Minecraft kick events provided by a Minecraft server
+   * Minecraft (POST Request) Player kick event ->        WebInterface
+   * Minecraft (POST Response)                  <- 200 OK WebInterface
+   *
+   * @param {Bridge} bridge Bridged room
+   * @param {MCEvents.Kick} kick Kick event to send
+   * @returns {Promise<void>}
+   * @throws {NotBridgedError}
+   */
+  public kickToMatrix(bridge: Bridge, kick: MCEvents.Kick) {
+    return this.matrix.sendKick(bridge, kick);
+  }
 }

--- a/src/matrix/MatrixInterface.ts
+++ b/src/matrix/MatrixInterface.ts
@@ -106,6 +106,100 @@ export class MatrixInterface {
   }
 
   /**
+   * This intakes a Minecraft join event and relays it the provided bridged
+   * room.
+   * @param {Bridge} bridge
+   * @param {MCEvents.Join} mcJoin
+   * @returns {Promise<void>}
+   */
+  public async sendJoin(bridge: Bridge, mcJoin: MCEvents.Join): Promise<void> {
+    // The player UUID is the Matrix appservice user's Matrix ID
+    const uuid = await mcJoin.player.getUUID();
+    // This is the representing Matrix user
+    const intent = this.appservice.getIntentForSuffix(uuid);
+
+    try {
+      await intent.ensureRegistered();
+      // Keep the player name, skin in sync with their profile data on Matrix
+      await this.main.players.sync(intent, mcJoin.player);
+
+      // Finally send the message to the room, half of these steps are
+      // skipped to this if everything has already been completed before
+      // (such as inviting, joining, and syncing unless the player updated a
+      // certain detail that we keep synced)
+    } catch (err) {
+      let errMessage = 'An error occurred while joining a bridged room.\n'
+      if (err instanceof Error) {
+        errMessage += ` - message: ${err.message}\n`;
+        errMessage += ` - stack:\n${err.stack}`;
+      } else {
+        errMessage += ' - error: ' + err;
+      }
+      LogService.error('marco-matrix', errMessage);
+    } finally {
+      // what matters most is that the room is joined.
+      await intent.joinRoom(
+        bridge.room
+      );
+    }
+  }
+
+  /**
+   * This intakes a Minecraft quit event and relays it the provided bridged
+   * room.
+   * @param {Bridge} bridge
+   * @param {MCEvents.Quit} mcQuit
+   * @returns {Promise<void>}
+   */
+  public async sendQuit(bridge: Bridge, mcQuit: MCEvents.Quit): Promise<void> {
+    // The player UUID is the Matrix appservice user's Matrix ID
+    const uuid = await mcQuit.player.getUUID();
+    // This is the representing Matrix user
+    const intent = this.appservice.getIntentForSuffix(uuid);
+
+    try {
+      await intent.ensureRegistered();
+      // We don't bother keeping the player name, skin in sync with their
+      // profile data on Matrix right now, since the player is leaving
+
+      // Finally send the event to the room, half of these steps are
+      // skipped to this if everything has already been completed before
+      // (such as inviting & joining)
+    } catch (err) {
+      let errMessage = 'An error occurred while leaving a bridged room.\n'
+      if (err instanceof Error) {
+        errMessage += ` - message: ${err.message}\n`;
+        errMessage += ` - stack:\n${err.stack}`;
+      } else {
+        errMessage += ' - error: ' + err;
+      }
+      LogService.error('marco-matrix', errMessage);
+    } finally {
+      // what matters most is that the room is left.
+      await intent.leaveRoom(
+        bridge.room
+      );
+    }
+  }
+
+  /**
+   * This intakes a Minecraft kick event and relays it the provided bridged
+   * room.
+   * @param {Bridge} bridge
+   * @param {MCEvents.Kick} mcKick
+   * @returns {Promise<void>}
+   */
+  public async sendKick(bridge: Bridge, mcKick: MCEvents.Kick): Promise<void> {
+    // The player UUID is the Matrix appservice user's Matrix ID
+    const uuid = await mcKick.player.getUUID();
+    // This is the representing Matrix bot user
+    const client = this.appservice.botClient;
+
+    // Perform the kick
+    client.kickUser(this.appservice.getUserIdForSuffix(uuid), bridge.room, mcKick.reason);
+  }
+
+  /**
    * This returns all the new room messages of a given bridge since the
    * last time requested.
    * @param {Bridge} bridge

--- a/src/matrix/MatrixInterface.ts
+++ b/src/matrix/MatrixInterface.ts
@@ -60,6 +60,7 @@ export class MatrixInterface {
     matrix.AutojoinRoomsMixin.setupOnAppservice(this.appservice);
 
     this.appservice.on('room.message', this.onMxMessage.bind(this));
+    this.appservice.on('query.user', this.onQueryUser.bind(this));
 
     await this.appservice.begin();
   }
@@ -190,5 +191,16 @@ export class MatrixInterface {
       // Give it to Main to handle
       this.main.sendToMinecraft(message);
     }
+  }
+
+  /**
+   * This queries a Minecraft user that doesn't exist, allowing the appservice
+   * to arrange for it to be created.
+   * @param {string} user User Matrix ID
+   * @param {createUser} Function Callback to create the new user
+   */
+  private async onQueryUser(user: string, createUser: Function): Promise<void> {
+    // Refuse to automatically create arbitrary new users for now
+    createUser(false);
   }
 }

--- a/src/matrix/MatrixInterface.ts
+++ b/src/matrix/MatrixInterface.ts
@@ -6,13 +6,14 @@ import type { Main } from "../Main";
 import { Bridge } from "../bridging";
 import { CmdManager } from "./internal/CmdManager";
 import { MsgProcessor } from "./internal/MsgProcessor";
-import type { MCEvents } from "../minecraft";
+import type { MxEvents, MCEvents } from "../minecraft";
 
 
 export type MxMessage = {
   sender: string;
   room: string;
-  body: string;
+  body?: string;
+  event: MxEvents.Event;
 }
 
 /**
@@ -28,7 +29,7 @@ export class MatrixInterface {
   public readonly appservice: matrix.Appservice;
   private readonly main: Main;
   // Collects new messages for Minecraft servers
-  private readonly newMxMessages: Map<string, string[]>
+  private readonly newMxMessages: Map<string, MxEvents.Event[]>
   // Handles commands given by Matrix users
   private readonly cmdManager: CmdManager;
   // Converts matrix messages into McMessages
@@ -203,9 +204,9 @@ export class MatrixInterface {
    * This returns all the new room messages of a given bridge since the
    * last time requested.
    * @param {Bridge} bridge
-   * @returns {string[]}
+   * @returns {MxEvents.Event[]}
    */
-  public getNewMxMessages(bridge: Bridge): string[] {
+  public getNewMxMessages(bridge: Bridge): MxEvents.Event[] {
     let newMxMessages = this.newMxMessages.get(bridge.room);
 
     if (!newMxMessages) {
@@ -224,7 +225,7 @@ export class MatrixInterface {
     const newMxMessages = this.newMxMessages.get(message.room) || [];
 
     if (!this.appservice.isNamespacedUser(message.sender))
-      newMxMessages.push(message.body);
+      newMxMessages.push(message.event);
 
     this.newMxMessages.set(message.room, newMxMessages);
   }

--- a/src/matrix/internal/CmdManager.ts
+++ b/src/matrix/internal/CmdManager.ts
@@ -1,6 +1,7 @@
 import { Appservice } from "matrix-bot-sdk";
 import { Main } from "../../Main";
 import { BridgeError } from "../../bridging";
+import { MxEvents } from "../../minecraft";
 
 
 /**
@@ -135,9 +136,17 @@ export class CmdManager {
 
     if (isBridged) {
       this.main.sendToMinecraft({
-        body: "[Server] " + body,
         room: room,
-        sender
+        sender,
+        body: `[Server] ${body}`,
+        event: <MxEvents.AnnounceMessageEvent> {
+          sender: {
+            mxid: sender,
+            displayName: sender
+          },
+          type: "message.announce",
+          body: body,
+        } as MxEvents.Event
       });
       await client.sendNotice(room, "Sent!");
     } else {

--- a/src/matrix/internal/MsgProcessor.ts
+++ b/src/matrix/internal/MsgProcessor.ts
@@ -1,5 +1,6 @@
 import { MatrixInterface, MxMessage } from "../MatrixInterface";
 import { MxEvents } from "../../minecraft";
+import { Player } from "../../minecraft/internal/Player";
 
 export class MsgProcessor {
   constructor(private readonly matrix: MatrixInterface) {}
@@ -60,6 +61,84 @@ export class MsgProcessor {
         },
         type: "message.text",
         body: body,
+      } as MxEvents.Event
+    };
+  }
+
+  public async buildKickMsg(room: string, event: any): Promise<MxMessage> {
+    const content = event['content'];
+    const reason = content['reason'];
+    const prevContent = event['prev_content'] || {};
+    const sender = event['sender'];
+    const victim = event['state_key'];
+
+    const senderRoomMember = await this.matrix.getRoomMember(room, sender);
+    const victimUUID: string | undefined = this.matrix.getPlayerUUID(victim);
+    const senderName: string = senderRoomMember['displayname'] || sender;
+    const victimName: string = prevContent['displayname'] || victimUUID;
+
+    return {
+      sender: sender,
+      room,
+      event: <MxEvents.KickPlayerEvent> {
+        sender: {
+          mxid: sender,
+          displayName: senderName
+        },
+        type: "player.kick",
+        player: new Player(victimName, victimUUID),
+        reason: reason
+      } as MxEvents.Event
+    };
+  }
+
+  public async buildBanMsg(room: string, event: any): Promise<MxMessage> {
+    const content = event['content'];
+    const reason = content['reason'];
+    const prevContent = event['prev_content'] || {};
+    const sender = event['sender'];
+    const victim = event['state_key'];
+
+    const senderRoomMember = await this.matrix.getRoomMember(room, sender);
+    const victimUUID: string | undefined = this.matrix.getPlayerUUID(victim);
+    const senderName: string = senderRoomMember['displayname'] || sender;
+    const victimName: string = prevContent['displayname'] || victimUUID;
+
+    return {
+      sender: sender,
+      room,
+      event: <MxEvents.BanPlayerEvent> {
+        sender: {
+          mxid: sender,
+          displayName: senderName
+        },
+        type: "player.ban",
+        player: new Player(victimName, victimUUID),
+        reason: reason
+      } as MxEvents.Event
+    };
+  }
+
+  public async buildUnbanMsg(room: string, event: any): Promise<MxMessage> {
+    const prevContent = event['prev_content'];
+    const sender = event['sender'];
+    const victim = event['state_key'];
+
+    const senderRoomMember = await this.matrix.getRoomMember(room, sender);
+    const victimUUID: string | undefined = this.matrix.getPlayerUUID(victim);
+    const senderName: string = senderRoomMember['displayname'] || sender;
+    const victimName: string = prevContent['displayname'] || victimUUID;
+
+    return {
+      sender: sender,
+      room,
+      event: <MxEvents.UnbanPlayerEvent> {
+        sender: {
+          mxid: sender,
+          displayName: senderName
+        },
+        type: "player.unban",
+        player: new Player(victimName, victimUUID)
       } as MxEvents.Event
     };
   }

--- a/src/matrix/internal/MsgProcessor.ts
+++ b/src/matrix/internal/MsgProcessor.ts
@@ -1,4 +1,5 @@
 import { MatrixInterface, MxMessage } from "../MatrixInterface";
+import { MxEvents } from "../../minecraft";
 
 export class MsgProcessor {
   constructor(private readonly matrix: MatrixInterface) {}
@@ -19,9 +20,17 @@ export class MsgProcessor {
     const name: string = roomMember['displayname'] || sender;
 
     return {
-      sender,
+      sender: sender,
       room,
       body: ` * <${name}> ${body}`,
+      event: <MxEvents.EmoteMessageEvent> {
+        sender: {
+          mxid: sender,
+          displayName: name
+        },
+        type: "message.emote",
+        body: body,
+      } as MxEvents.Event
     };
   }
 
@@ -41,9 +50,17 @@ export class MsgProcessor {
     const name: string = roomMember['displayname'] || sender;
 
     return {
-      sender,
+      sender: sender,
       room,
       body: `<${name}> ${body}`,
+      event: <MxEvents.TextMessageEvent> {
+        sender: {
+          mxid: sender,
+          displayName: name
+        },
+        type: "message.text",
+        body: body,
+      } as MxEvents.Event
     };
   }
 }

--- a/src/minecraft/internal/types.ts
+++ b/src/minecraft/internal/types.ts
@@ -65,6 +65,47 @@ export module MxEvents {
   export interface AnnounceMessageEvent extends MessageEvent {
     type: "message.announce";
   }
+
+  /**
+   * A player event is one that relates to a specific player.
+   * It is further extended depending on the type string.
+   * @type PlayerEvent
+   * @prop {Player} player The player this event relates to
+   */
+  export interface PlayerEvent extends Event {
+    player: Player;
+  }
+
+  /**
+   * A player has been kicked from the room by a Matrix user.
+   * The Minecraft server may wish to kick the player from the server too.
+   * @type KickPlayerEvent
+   * @prop {string} reason The optional reason for the kicking
+   */
+  export interface KickPlayerEvent extends PlayerEvent {
+    type: "player.kick";
+    reason?: string;
+  }
+
+  /**
+   * A player has been banned from the room by a Matrix user.
+   * The Minecraft server may wish to ban the player from the server too.
+   * @type BanPlayerEvent
+   * @prop {string} reason The optional reason for the banning
+   */
+  export interface BanPlayerEvent extends PlayerEvent {
+    type: "player.ban";
+    reason?: string;
+  }
+
+  /**
+   * A player has been unbanned from the room by a Matrix user.
+   * The Minecraft server may wish to unban the player from the server too.
+   * @type UnbanPlayerEvent
+   */
+  export interface UnbanPlayerEvent extends PlayerEvent {
+    type: "player.unban";
+  }
 }
 
 export module MCEvents {

--- a/src/minecraft/internal/types.ts
+++ b/src/minecraft/internal/types.ts
@@ -16,10 +16,36 @@ export module MCEvents {
    * This represents a message coming from a player on Minecraft.
    * @type Message
    * @prop {Player} player The player that sent the message
-   * @prop {string} body The body of the message
+   * @prop {string} message The body of the message
    */
   export interface Message extends Event {
     message: string;
+  }
+
+  /**
+   * This represents a player joining the Minecraft server.
+   * @type Join
+   * @prop {Player} player The player that joined
+   */
+  export interface Join extends Event {
+  }
+
+  /**
+   * This represents a player quitting the Minecraft server.
+   * @type Quit
+   * @prop {Player} player The player that quit
+   */
+  export interface Quit extends Event {
+  }
+
+  /**
+   * This represents a player getting kicked from the Minecraft server.
+   * @type Kick
+   * @prop {Player} player The player that was kicked
+   * @prop {string} reason The kick reason
+   */
+  export interface Kick extends Event {
+    reason: string;
   }
 }
 

--- a/src/minecraft/internal/types.ts
+++ b/src/minecraft/internal/types.ts
@@ -7,6 +7,66 @@
 import type { Player } from "./Player";
 
 
+export module MxEvents {
+  /**
+   * This represents a Matrix user.
+   * @type User
+   * @prop {string} msid Full Matrix ID in the form @localpart:homeserver
+   * @prop {string} displayName More readable name of Matrix user
+   */
+  export type User = {
+    mxid: string;
+    displayName: string;
+  }
+
+  /**
+   * This represents an event from Matrix that Minecraft needs to handle.
+   * It is extended depending on the type string.
+   * @type Event
+   * @prop {User} sender The Matrix user who originated the event
+   * @prop {string} type An identifier to determine the type of event
+   */
+  export interface Event {
+    sender: User;
+    type: string;
+  }
+
+  /**
+   * A message event is one that usually ends up being send to broadcast to
+   * Minecraft users.
+   * It is further extended depending on the type string.
+   * @type MessageEvent
+   * @prop {string} body Message body
+   */
+  export interface MessageEvent extends Event {
+    body: string;
+  }
+
+  /**
+   * A normal text message send from a Matrix user.
+   * @type TextMessageEvent
+   */
+  export interface TextMessageEvent extends MessageEvent {
+    type: "message.text";
+  }
+
+  /**
+   * An emote message send from a Matrix user.
+   * @type EmoteMessageEvent
+   */
+  export interface EmoteMessageEvent extends MessageEvent {
+    type: "message.emote";
+  }
+
+  /**
+   * An announcement message send from a sufficiently privileged Matrix user.
+   * @type AnnounceMessageEvent
+   */
+  export interface AnnounceMessageEvent extends MessageEvent {
+    type: "message.announce";
+  }
+}
+
 export module MCEvents {
   export type Event = {
     player: Player;

--- a/src/webserver/WebInterface.ts
+++ b/src/webserver/WebInterface.ts
@@ -3,6 +3,7 @@ import type { Config } from "../Config";
 import type { Main } from "../Main";
 import { BridgeError } from "../bridging";
 import { chatRouter } from "./internal/routes";
+import { playerRouter } from "./internal/routes";
 import { LogService } from "matrix-bot-sdk";
 import { v1 as uuid } from "uuid";
 import * as Errors from "./internal/errors";
@@ -28,9 +29,13 @@ export class WebInterface {
 
     // Check all authorization headers at these endpoints
     app.use('/chat', this.checkAuth.bind(this));
+    app.use('/player', this.checkAuth.bind(this));
 
     // Chat endpoint for getting messages and posting minecraft chat messages
     app.use('/chat', chatRouter);
+
+    // Player endpoint for posting minecraft player events
+    app.use('/player', playerRouter);
   }
 
   /**

--- a/src/webserver/WebInterface.ts
+++ b/src/webserver/WebInterface.ts
@@ -4,6 +4,7 @@ import type { Main } from "../Main";
 import { BridgeError } from "../bridging";
 import { chatRouter } from "./internal/routes";
 import { playerRouter } from "./internal/routes";
+import { getEvents } from "./internal/getEvents";
 import { LogService } from "matrix-bot-sdk";
 import { v1 as uuid } from "uuid";
 import * as Errors from "./internal/errors";
@@ -29,10 +30,14 @@ export class WebInterface {
 
     // Check all authorization headers at these endpoints
     app.use('/chat', this.checkAuth.bind(this));
+    app.use('/events', this.checkAuth.bind(this));
     app.use('/player', this.checkAuth.bind(this));
 
     // Chat endpoint for getting messages and posting minecraft chat messages
     app.use('/chat', chatRouter);
+
+    // Events endpoint for getting messages and events from Matrix
+    app.get('/events', getEvents);
 
     // Player endpoint for posting minecraft player events
     app.use('/player', playerRouter);

--- a/src/webserver/internal/errors.ts
+++ b/src/webserver/internal/errors.ts
@@ -48,12 +48,30 @@ export const noMessageError = {
 };
 
 /**
+ * Polo didn't provide a reason
+ * @const noReasonError
+ */
+export const noReasonError = {
+  "error": "NO_REASON",
+  "message": "Provide a reason property"
+};
+
+/**
  * Polo provided a message but it's not a string
  * @const messageTypeError
  */
 export const messageTypeError = {
   "error": "MESSAGE_TYPE",
   "message": "The message property must be type of string"
+};
+
+/**
+ * Polo provided a reason but it's not a string
+ * @const reasonTypeError
+ */
+export const reasonTypeError = {
+  "error": "REASON_TYPE",
+  "message": "The reason property must be type of string"
 };
 
 /**

--- a/src/webserver/internal/getEvents.ts
+++ b/src/webserver/internal/getEvents.ts
@@ -1,0 +1,34 @@
+import type { Request, Response } from "express";
+import type { Main } from "../../Main";
+import type { Bridge } from "../../bridging";
+import type { MxEvents } from "../../minecraft";
+import { LogService } from "matrix-bot-sdk";
+
+
+/**
+ * GET /events/
+ * Polo will call this endpoint to get all the events from the Matrix room
+ * @param {Request} req
+ * @param {Response} res
+ */
+export function getEvents(req: Request, res: Response) {
+  // @ts-ignore
+  const main: Main = req['main'];
+  // @ts-ignore
+  const bridge: Bridge = req['bridge'];
+  // @ts-ignore
+  const id = req['id'];
+  const events = main.getNewMxMessages(bridge);
+  const chat = {
+    events: events
+  };
+
+  res.status(200);
+  res.send(chat);
+  res.end();
+  LogService.info(
+    'WebInterface',
+    `[Request ${id}]: Finished.`
+  );
+}
+

--- a/src/webserver/internal/routes/chat/chatRouter.ts
+++ b/src/webserver/internal/routes/chat/chatRouter.ts
@@ -3,7 +3,8 @@
  */
 import express, { Request } from 'express';
 import { getChat } from "./getChat";
-import { checkIntegrity, postChat } from "./postChat";
+import { checkChatIntegrity, postChat } from "./postChat";
+import { validatePost, handlePostAsync, handleGet, checkPlayerIntegrity } from "../../validate";
 import { LogService } from "matrix-bot-sdk";
 
 
@@ -19,50 +20,13 @@ chatRouter.use('/', (_, res, next) => {
  * GET /chat/
  * Polo will call this endpoint to get all the messages from the Matrix room
  */
-chatRouter.get('/', ((req, res) => {
-  try {
-    getChat(req, res);
-  } catch (err) {
-    errorHandler(req, err);
-  }
-}));
-
-// this checks to make sure Polo is calling this endpoint properly
-chatRouter.post('/', ((req, res, next) => {
-  try {
-    checkIntegrity(req, res, next);
-  } catch (err) {
-    errorHandler(req, err);
-  }
-}));
+handleGet(chatRouter, '/', getChat);
 
 /**
  * POST /chat/
  * Polo will call this endpoint when there's a new message in the
  * Minecraft chat
  */
-chatRouter.post('/', (async (req, res) => {
-  try {
-    await postChat(req, res);
-  } catch (err) {
-    errorHandler(req, err);
-  }
-}));
-
-function errorHandler(req: Request, err: any): void {
-  // @ts-ignore
-  const id = req['id'];
-  if (err instanceof Error) {
-    LogService.error(
-      'marco-webserver',
-      `Request ${id}`,
-      err.message,
-    );
-  } else {
-    LogService.error(
-      'marco-webserver',
-      `Request ${id}`,
-      err
-    );
-  }
-}
+validatePost(chatRouter, '/', checkPlayerIntegrity);
+validatePost(chatRouter, '/', checkChatIntegrity);
+handlePostAsync(chatRouter, '/', postChat);

--- a/src/webserver/internal/routes/chat/getChat.ts
+++ b/src/webserver/internal/routes/chat/getChat.ts
@@ -1,12 +1,15 @@
 import type { Request, Response } from "express";
 import type { Main } from "../../../../Main";
 import type { Bridge } from "../../../../bridging";
+import type { MxEvents } from "../../../../minecraft";
 import { LogService } from "matrix-bot-sdk";
 
 
 /**
  * GET /chat/
- * Polo will call this endpoint to get all the messages from the Matrix room
+ * Polo will call this endpoint to get all the messages from the Matrix room.
+ * This is a legacy interface provided only for compatibility, and will discard
+ * any non-message events. Please use the /chat/events/ endpoint instead.
  * @param {Request} req
  * @param {Response} res
  */
@@ -17,7 +20,27 @@ export function getChat(req: Request, res: Response) {
   const bridge: Bridge = req['bridge'];
   // @ts-ignore
   const id = req['id'];
-  const messages = main.getNewMxMessages(bridge);
+  let messages: string[] = []
+  main.getNewMxMessages(bridge).forEach(
+    function (rawEvent) {
+      switch (rawEvent['type']) {
+        case "message.emote": {
+          let event = rawEvent as MxEvents.EmoteMessageEvent;
+          messages.push(` * <${event['sender']['displayName']}> ${event['body']}`);
+          break;
+        }
+        case "message.text": {
+          let event = rawEvent as MxEvents.TextMessageEvent;
+          messages.push(`<${event['sender']['displayName']}> ${event['body']}`);
+          break;
+        }
+        case "message.announce": {
+          let event = rawEvent as MxEvents.AnnounceMessageEvent;
+          messages.push(`[Server] ${event['body']}`);
+          break;
+        }
+      }
+    });
   const chat = {
     chat: messages
   };

--- a/src/webserver/internal/routes/chat/postChat.ts
+++ b/src/webserver/internal/routes/chat/postChat.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import * as Errors from "../../errors";
+import { fail } from "../../validate";
 import { Main } from "../../../../Main";
 import { Bridge } from "../../../../bridging";
 import { LogService } from "matrix-bot-sdk";
@@ -54,21 +55,15 @@ export async function postChat(req: Request, res: Response): Promise<void> {
  * @param {Response} res
  * @param {NextFunction} next
  */
-export function checkIntegrity(req: Request, res: Response, next: NextFunction) {
+export function checkChatIntegrity(req: Request, res: Response, next: NextFunction) {
   // @ts-ignore
   const reqID = req['id'];
   const body = req.body;
 
   LogService.info(
     'WebInterface',
-    `[Request ${reqID}]: Checking Body Integrity`
+    `[Request ${reqID}]: Checking Chat Body Integrity`
   );
-
-  // Check if body is defined
-  if (body == undefined) {
-    fail(res, Errors.noBodyError);
-    return;
-  }
 
   // Check message
   const message = body['message'];
@@ -85,50 +80,6 @@ export function checkIntegrity(req: Request, res: Response, next: NextFunction) 
     `[Request ${reqID}]: Message "${message}"`
   )
 
-  // Check player
-  const player = body['player'];
-  if (player == undefined) {
-    fail(res, Errors.noPlayerError);
-    return;
-  } else if (!(typeof player == 'object')) {
-    fail(res, Errors.playerTypeError);
-    return;
-  }
-
-  // Check <player>.name
-  const name = player.name;
-  if (name == undefined) {
-    fail(res, Errors.noPlayerNameError);
-    return;
-  } else if (!(typeof name == 'string')) {
-    fail(res, Errors.playerNameTypeError);
-    return;
-  }
-
-  LogService.debug(
-    'WebInterface',
-    `[Request ${reqID}]: Player name "${name}"`
-  );
-
-  // Check <player>.uuid
-  const uuid = player.uuid;
-  if (uuid == undefined) {
-    fail(res, Errors.noPlayerIdError);
-  } else if (!(typeof uuid == 'string')) {
-    fail(res, Errors.playerIdTypeError);
-    return;
-  }
-
-  LogService.debug(
-    'WebInterface',
-    `[Request ${reqID}]: Player UUID "${uuid}"`
-  );
-
-  LogService.info(
-    'WebInterface',
-    `[Request ${reqID}]: Integrity Check Passed`
-  );
-
   /**
    * If the integrity passed this is what the body should look like:
    * {
@@ -140,10 +91,4 @@ export function checkIntegrity(req: Request, res: Response, next: NextFunction) 
    * }
    */
   next();
-}
-
-function fail(res: Response, error: object): void {
-  res.status(400);
-  res.send(error);
-  res.end();
 }

--- a/src/webserver/internal/routes/index.ts
+++ b/src/webserver/internal/routes/index.ts
@@ -1,1 +1,2 @@
 export { chatRouter } from './chat/chatRouter';
+export { playerRouter } from './player/playerRouter';

--- a/src/webserver/internal/routes/player/playerRouter.ts
+++ b/src/webserver/internal/routes/player/playerRouter.ts
@@ -1,0 +1,40 @@
+/**
+ * This is the player endpoint it allows Polo to send player events
+ */
+import express, { Request } from 'express';
+import { postJoin } from "./postJoin";
+import { postQuit } from "./postQuit";
+import { postKick, checkKickIntegrity } from "./postKick";
+import { validatePost, handlePostAsync, checkPlayerIntegrity } from "../../validate";
+import { LogService } from "matrix-bot-sdk";
+
+
+export const playerRouter = express.Router();
+
+playerRouter.use('/', express.json());
+playerRouter.use('/', (_, res, next) => {
+  res.setHeader('Content-Type', 'application/json');
+  next();
+})
+
+/**
+ * POST /player/join/
+ * Polo will call this endpoint when a user joins the minecraft server
+ */
+validatePost(playerRouter, '/join', checkPlayerIntegrity);
+handlePostAsync(playerRouter, '/join', postJoin);
+
+/**
+ * POST /player/quit/
+ * Polo will call this endpoint when a user quits the minecraft server
+ */
+validatePost(playerRouter, '/quit', checkPlayerIntegrity);
+handlePostAsync(playerRouter, '/quit', postQuit);
+
+/**
+ * POST /player/kick/
+ * Polo will call this endpoint when a user quits the minecraft server
+ */
+validatePost(playerRouter, '/kick', checkPlayerIntegrity);
+validatePost(playerRouter, '/kick', checkKickIntegrity);
+handlePostAsync(playerRouter, '/kick', postKick);

--- a/src/webserver/internal/routes/player/postJoin.ts
+++ b/src/webserver/internal/routes/player/postJoin.ts
@@ -1,0 +1,44 @@
+import { Request, Response } from "express";
+import { Main } from "../../../../Main";
+import { Bridge } from "../../../../bridging";
+import { LogService } from "matrix-bot-sdk";
+import { MCEvents } from "../../../../minecraft";
+
+
+/**
+ * POST /player/join
+ * Polo will call this endpoint when a user joins the Minecraft server
+ * Example body:
+ * {
+ *   "player": {
+ *     "name": <player name string>,
+ *     "uuid": <player uuid string>
+ *   }
+ * }
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<void>}
+ */
+export async function postJoin(req: Request, res: Response): Promise<void> {
+  // @ts-ignore
+  const main: Main = req['main'];
+  // @ts-ignore
+  const bridge: Bridge = req['bridge'];
+  // @ts-ignore
+  const id: string = req['id'];
+  const body = req.body;
+  const playerRaw: { name: string, uuid: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const mcJoin: MCEvents.Join = {
+    player
+  }
+
+  await main.joinToMatrix(bridge, mcJoin);
+  res.status(200);
+  res.end();
+  LogService.info(
+    'marco-webserver',
+    `Request ${id}`,
+    '- Finished.'
+  );
+}

--- a/src/webserver/internal/routes/player/postKick.ts
+++ b/src/webserver/internal/routes/player/postKick.ts
@@ -1,0 +1,94 @@
+import { NextFunction, Request, Response } from "express";
+import { Main } from "../../../../Main";
+import { Bridge } from "../../../../bridging";
+import { LogService } from "matrix-bot-sdk";
+import { MCEvents } from "../../../../minecraft";
+import { fail } from "../../validate";
+import * as Errors from "../../errors";
+
+
+/**
+ * POST /player/kick
+ * Polo will call this endpoint when a user gets kicked from the Minecraft server
+ * Example body:
+ * {
+ *   "reason": <kick reason>,
+ *   "player": {
+ *     "name": <player name string>,
+ *     "uuid": <player uuid string>
+ *   }
+ * }
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<void>}
+ */
+export async function postKick(req: Request, res: Response): Promise<void> {
+  // @ts-ignore
+  const main: Main = req['main'];
+  // @ts-ignore
+  const bridge: Bridge = req['bridge'];
+  // @ts-ignore
+  const id: string = req['id'];
+  const body = req.body;
+  const reason: string = body['reason'];
+  const playerRaw: { name: string, uuid: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const mcKick: MCEvents.Kick = {
+    reason,
+    player
+  }
+
+  await main.kickToMatrix(bridge, mcKick);
+  res.status(200);
+  res.end();
+  LogService.info(
+    'marco-webserver',
+    `Request ${id}`,
+    '- Finished.'
+  );
+}
+
+/**
+ * This checks the body of the request to make sure everything checks up
+ * correctly.
+ * @param {Request} req
+ * @param {Response} res
+ * @param {NextFunction} next
+ */
+export function checkKickIntegrity(req: Request, res: Response, next: NextFunction) {
+  // @ts-ignore
+  const reqID = req['id'];
+  const body = req.body;
+
+  LogService.info(
+    'WebInterface',
+    `[Request ${reqID}]: Checking Kick Body Integrity`
+  );
+
+  // Check reason
+  const reason = body['reason'];
+  if (reason == undefined) {
+    fail(res, Errors.noReasonError);
+    return;
+  } else if (!(typeof reason == 'string')) {
+    fail(res, Errors.reasonTypeError);
+    return;
+  }
+
+  LogService.debug(
+    'WebInterface',
+    `[Request ${reqID}]: Reason "${reason}"`
+  )
+
+  /**
+   * If the integrity passed this is what the body should look like:
+   * {
+   *   "reason": "The reason for the kick",
+   *   "player" {
+   *     "name": "player name",
+   *     "uuid": "player uuid"
+   *   }
+   * }
+   */
+  next();
+}

--- a/src/webserver/internal/routes/player/postQuit.ts
+++ b/src/webserver/internal/routes/player/postQuit.ts
@@ -1,0 +1,44 @@
+import { Request, Response } from "express";
+import { Main } from "../../../../Main";
+import { Bridge } from "../../../../bridging";
+import { LogService } from "matrix-bot-sdk";
+import { MCEvents } from "../../../../minecraft";
+
+
+/**
+ * POST /player/quit
+ * Polo will call this endpoint when a user quits the Minecraft server
+ * Example body:
+ * {
+ *   "player": {
+ *     "name": <player name string>,
+ *     "uuid": <player uuid string>
+ *   }
+ * }
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<void>}
+ */
+export async function postQuit(req: Request, res: Response): Promise<void> {
+  // @ts-ignore
+  const main: Main = req['main'];
+  // @ts-ignore
+  const bridge: Bridge = req['bridge'];
+  // @ts-ignore
+  const id: string = req['id'];
+  const body = req.body;
+  const playerRaw: { name: string, uuid: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const mcQuit: MCEvents.Quit = {
+    player
+  }
+
+  await main.quitToMatrix(bridge, mcQuit);
+  res.status(200);
+  res.end();
+  LogService.info(
+    'marco-webserver',
+    `Request ${id}`,
+    '- Finished.'
+  );
+}

--- a/src/webserver/internal/validate.ts
+++ b/src/webserver/internal/validate.ts
@@ -1,0 +1,141 @@
+import { NextFunction, Router, Request, Response } from 'express';
+import { LogService } from "matrix-bot-sdk";
+
+import * as Errors from "./errors";
+
+export function validatePost(router: Router, endpoint: string, callback: Function) {
+  // this checks to make sure Polo is calling the endpoint properly
+  router.post(endpoint, ((req, res, next) => {
+    try {
+      callback(req, res, next);
+    } catch (err) {
+      errorHandler(req, err);
+    }
+  }));
+}
+
+export function handlePostAsync(router: Router, endpoint: string, callback: Function) {
+  // this checks to make sure Polo is calling the endpoint properly
+  router.post(endpoint, (async (req, res) => {
+    try {
+      await callback(req, res);
+    } catch (err) {
+      errorHandler(req, err);
+    }
+  }));
+}
+
+export function handleGet(router: Router, endpoint: string, callback: Function) {
+  // this checks to make sure Polo is calling the endpoint properly
+  router.get(endpoint, ((req, res) => {
+    try {
+      callback(req, res);
+    } catch (err) {
+      errorHandler(req, err);
+    }
+  }));
+}
+
+function errorHandler(req: Request, err: any): void {
+  // @ts-ignore
+  const id = req['id'];
+  if (err instanceof Error) {
+    LogService.error(
+      'marco-webserver',
+      `Request ${id}`,
+      err.message,
+    );
+  } else {
+    LogService.error(
+      'marco-webserver',
+      `Request ${id}`,
+      err
+    );
+  }
+}
+
+/**
+ * This checks the body of the request to make sure everything checks up
+ * correctly.
+ * @param {Request} req
+ * @param {Response} res
+ * @param {NextFunction} next
+ */
+export function checkPlayerIntegrity(req: Request, res: Response, next: NextFunction) {
+  // @ts-ignore
+  const reqID = req['id'];
+  const body = req.body;
+
+  LogService.info(
+    'WebInterface',
+    `[Request ${reqID}]: Checking Body Integrity`
+  );
+
+  // Check if body is defined
+  if (body == undefined) {
+    fail(res, Errors.noBodyError);
+    return;
+  }
+
+  // Check player
+  const player = body['player'];
+  if (player == undefined) {
+    fail(res, Errors.noPlayerError);
+    return;
+  } else if (!(typeof player == 'object')) {
+    fail(res, Errors.playerTypeError);
+    return;
+  }
+
+  // Check <player>.name
+  const name = player.name;
+  if (name == undefined) {
+    fail(res, Errors.noPlayerNameError);
+    return;
+  } else if (!(typeof name == 'string')) {
+    fail(res, Errors.playerNameTypeError);
+    return;
+  }
+
+  LogService.debug(
+    'WebInterface',
+    `[Request ${reqID}]: Player name "${name}"`
+  );
+
+  // Check <player>.uuid
+  const uuid = player.uuid;
+  if (uuid == undefined) {
+    fail(res, Errors.noPlayerIdError);
+  } else if (!(typeof uuid == 'string')) {
+    fail(res, Errors.playerIdTypeError);
+    return;
+  }
+
+  LogService.debug(
+    'WebInterface',
+    `[Request ${reqID}]: Player UUID "${uuid}"`
+  );
+
+  LogService.info(
+    'WebInterface',
+    `[Request ${reqID}]: Integrity Check Passed`
+  );
+
+  /**
+   * If the integrity passed this is what the body should look like:
+   * {
+   *   "reason": "The reason for the kick",
+   *   "player" {
+   *     "name": "player name",
+   *     "uuid": "player uuid"
+   *   }
+   * }
+   */
+  next();
+}
+
+export function fail(res: Response, error: object): void {
+  res.status(400);
+  res.send(error);
+  res.end();
+}


### PR DESCRIPTION
This PR is mainly to solicit feedback, we should probably get the new APIs right before merging anything.

It corresponds to https://github.com/dhghf/matrix-plugin/pull/12

This implements first Join/Quit/Kick endpoints, so that the plugin can notify the appservice of the need for fake Minecraft users to join, leave, or be kicked by the mcbot from the bridged channel. It is up to the plugin whether to use these. This commit is slightly hacky in that it reuses the formats of the POST /chat event.

* [x] Don't reuse format of POST /chat event

It then adds a new primary endpoint for retrieving structured events from the appservice, with the old style plain text messages endpoint becoming a wrapper. I'm still not entirely sure it makes sense to delegate formatting to the plugin, but in some cases at least it probably makes sense (I haven't really got my head around JSON formatted messages yet).

* [ ] Does it make sense to delegate formatting to plugin?
* [ ] Include a fallback text to broadcast for when the plugin doesn't support the event type
* [x] I based the type ID's on the ids posted the other day in the matrix room, but I now realise that may have been referring to Matrix events, rather than this plugin->appservice API. These could probably be simplified

Finally we extend the structured events to include kick, ben, and unban events for when Minecraft users are kicked, banned or unbanned from the bridged room. It is up to the plugin whether to act on these.