### PR TITLE
Command handling fixes, incl privilege checking & optional user whitelist for bridge cmd

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -11,6 +11,7 @@ export type AppserviceConfig = {
   bindAddress: string;
   port: number;
   regPath: string;
+  userWhitelist: string[] | undefined;
 }
 
 export type WebserverConfig = {
@@ -35,7 +36,8 @@ export class Config {
       bindAddress: '0.0.0.0',
       homeserverName: 'matrix.org',
       homeserverURL: 'https://matrix.org',
-      regPath: Config.configRoot + '/appservice.yaml'
+      regPath: Config.configRoot + '/appservice.yaml',
+      userWhitelist: []
     };
     this.webserver = {
       privKey: uuid(),

--- a/src/bridging/BridgeManager.ts
+++ b/src/bridging/BridgeManager.ts
@@ -72,10 +72,10 @@ export class BridgeManager {
 
   /**
    * This breaks a bridge
-   * @param {string} id Bridge identifier
+   * @param {string} room Room to unbridge
    * @returns {boolean} Whether or not it was successful
    */
-  public unbridge(id: string): boolean {
-    return this.db.unBridge(id);
+  public unbridge(room: string): boolean {
+    return this.db.unBridge(room);
   }
 }

--- a/src/db/tables/BridgeTable.ts
+++ b/src/db/tables/BridgeTable.ts
@@ -50,13 +50,13 @@ export class BridgeTable {
 
   /**
    * This deletes a bridge establishment
-   * @param {string} id Bridge identifier
+   * @param {string} room Room ID
    * @returns {boolean} Whether it worked or not
    */
-  public unBridge(id: string): boolean {
+  public unBridge(room: string): boolean {
     const info = this.db.prepare(
-      'DELETE FROM bridging WHERE id=?'
-    ).run(id);
+      'DELETE FROM bridging WHERE room=?'
+    ).run(room);
 
     return (info.changes > 0);
   }

--- a/src/matrix/MatrixInterface.ts
+++ b/src/matrix/MatrixInterface.ts
@@ -47,7 +47,7 @@ export class MatrixInterface {
       homeserverUrl: config.appservice.homeserverURL,
       port: config.appservice.port
     });
-    this.cmdManager = new CmdManager(this.appservice, this.main);
+    this.cmdManager = new CmdManager(this.appservice, this.main, config);
     this.newMxMessages = new Map();
   }
 

--- a/src/matrix/internal/CmdManager.ts
+++ b/src/matrix/internal/CmdManager.ts
@@ -109,6 +109,15 @@ export class CmdManager {
           "Something went wrong: " + err.message
         );
       }
+    } else if (err instanceof Object &&
+               err.body instanceof Object &&
+               typeof err.body.error === 'string') {
+      // The error string from the Matrix server may be in there containing
+      // useful feedback
+      await client.sendNotice(
+        room,
+        'Something went wrong: ' + err.body.error
+      );
     } else {
       await client.sendNotice(
         room,
@@ -159,10 +168,6 @@ export class CmdManager {
     try {
       // Get the room they're referring to
       const target = await client.resolveRoom(args[2] || '');
-      if (!target) {
-        await client.sendNotice(room, "That room doesn't exist");
-        return;
-      }
 
       // See if the user has state_default perms
       const hasPerms = await this.checkPrivilege(room, sender);
@@ -193,11 +198,6 @@ export class CmdManager {
     try {
       // Get the room they're referring to
       const target = await client.resolveRoom(args[2] || '');
-
-      if (!target) {
-        await client.sendNotice(room, "That room doesn't exist");
-        return;
-      }
 
       // See if the user has state_default perms
       const hasPerms = await this.checkPrivilege(room, sender);

--- a/src/matrix/internal/CmdManager.ts
+++ b/src/matrix/internal/CmdManager.ts
@@ -15,7 +15,7 @@ export class CmdManager {
     " - bridge <room ID>: This will provide an access token to give a" +
     " Minecraft server to send and retrieve messages in the room with.\n" +
     // see <CmdBridge>.handleUnbridge method
-    " - unbridge <room ID>: This will forcefully invalidate any tokens" +
+    " - unbridge [<room ID>]: This will forcefully invalidate any tokens" +
     " corresponding with this room\n" +
     ' - announce <...announcement>: This will send an announcement as' +
     ' "Server". Send this command in a bridged room.'
@@ -197,7 +197,7 @@ export class CmdManager {
 
     try {
       // Get the room they're referring to
-      const target = await client.resolveRoom(args[2] || '');
+      const target = await client.resolveRoom(args[2] || room);
 
       // See if the user has state_default perms
       const hasPerms = await this.checkPrivilege(room, sender);


### PR DESCRIPTION
These patches improve the bridge & unbridge command handling:
* `!minecraft unbridge` is now done by room ID, fixing the weird UX of can't bridge or unbridge
* Drop dead resolveRoom error handling and add reporting of homeserver errors from user commands
* `!minecraft unbridge` targets current room by default, making unbridging easier
* Priv checks fixed to check power of user in the targetted room, not the command room
* The _mc_bot is now required to be present in a room before it can be bridged, which allows the appservice to verify the power level in the room of the user requesting the bridging
* New `userWhitelist` config, optionally limiting users who can perform `!minecraft bridge` command to those in whitelist