### PR TITLE
Formatted text

### DIFF
--- a/docs/BodyJson.md
+++ b/docs/BodyJson.md
@@ -1,0 +1,193 @@
+# Message Body JSON Format
+This is the intermediate JSON format used to represent formatted Matrix message
+bodies. It is designed in such a way as to:
+ - Remove the burden of interpreting the original HTML from the Minecraft
+   plugin, so e.g. whitespace around elements is fully expanded.
+ - Be abstract enough from the Minecraft raw JSON format to be unaffected by
+   incompatibilities between Minecraft versions.
+ - Be unconcerned with nitty gritty Minecraft specifics such as indentation and
+   line lengths.
+ - Allow the same message to be displayed differently to different players (for
+   example when certain players are mentioned).
+
+## BodyJson:
+A BodyJson represents a snippet of formatted message text.
+
+This may be one of several types:
+ - A string, which must be presented as plain text.
+ - An array of BodyJson types, for which each item in the array must be
+   presented in succession.
+ - An object with at least the following fields, but may have more depending on
+   the type, which should be presented depending on the type.
+
+| Attribute | Type     | Description        |
+|-----------|----------|--------------------|
+| type      | string   | A type identifier. |
+| content   | BodyJson | Optional content.  |
+
+If the type isn't recognised, the Minecraft plugin must fall back to presenting
+the content field if present.
+
+### BodyStyle Object:
+A style object alters the way in which the content should be visually presented
+to the player. It extends the BodyJson object with the following additional
+fields:
+
+| Attribute | Type     | Description                                            |
+|-----------|----------|--------------------------------------------------------|
+| type      | string   | must be "style".                                       |
+| content   | BodyJson | Content affected by the style.                         |
+| color     | integer  | Optional 24-bit integer representing color of content. |
+| bold      | true     | Optionally present the content in bold.                |
+| italic    | true     | Optionally present the content in italics.             |
+| underline | true     | Optionally present the content underlined.             |
+| strike    | true     | Optionally present the content strike-through.         |
+| spoiler   | true     | Optionally present the content as a spoiler.           |
+| code      | true     | Optionally present the content as code.                |
+| heading   | 1..6     | Optionally present the content as a heading.           |
+
+The content of spoiler text is expected to be presented obfuscated with the
+non-obfuscated content shown when the player hovers over it.
+
+Headings correspond to HTML heading levels and should be presented in bold.
+
+### BodyLink Object:
+A link object adds a URL to the content, much like an HTML hyperlink. It
+extends the BodyJson object with the following additional fields:
+
+| Attribute | Type     | Description                     |
+|-----------|----------|---------------------------------|
+| type      | string   | must be "link".                 |
+| content   | BodyJson | Content with the link attached. |
+| href      | string   | URL of hyperlink.               |
+
+The content is expected to be presented underlined with the href as the hover
+text, and to open the href when clicked.
+
+### BodyMention Object:
+A mention object marks the content as mentioning a specific user in the Matrix
+room, or everybody. It extends the BodyJson object with the following
+additional fields, but may have more fields depending on the bridge identifier:
+
+| Attribute | Type     | Description                             |
+|-----------|----------|-----------------------------------------|
+| type      | string   | must be "mention".                      |
+| content   | BodyJson | Content to present as the mention text. |
+| room      | true     | Optionally mention the whole room.      |
+| user      | MxUser   | Optional matrix user information.       |
+| bridge    | string   | Optional bridge identifier.             |
+
+See [Endpoints](./Endpoints.md) for documentation about the MxUser object.
+
+The plugin may for example use these fields to present more information about
+the user as hover text, and allow the player to paste the mentioned user's
+displayName with shift+click.
+
+If the whole room is mentioned, the whole message should be presented
+highlighted (e.g. red text) for all players.
+
+Further fields may be interpreted depending on the bridge identifier if it is
+recognised.
+
+### BodyMentionMinecraft Object:
+A Minecraft mention object marks the content as mentioning a Minecraft player
+specifically. It extends the BodyMention object with the following additional
+fields:
+
+| Attribute | Type            | Description                   |
+|-----------|-----------------|-------------------------------|
+| bridge    | string          | must be "minecraft".          |
+| player    | MinecraftPlayer | Minecraft player information. |
+
+The whole message should be presented highlighted (e.g. red text) for any
+mentioned players.
+
+In addition to the handling of generic mentions, the plugin may also for
+example suggest an appropriate command to whisper to the mentioned player when
+the content is clicked.
+
+#### MinecraftPlayer Object:
+A Minecraft player object specifies a Minecraft player known to the bridge. It
+has the following fields:
+
+| Attribute | Type   | Description                       |
+|-----------|--------|-----------------------------------|
+| uuid      | string | The player's UUID in string form. |
+
+### BodyImg Object:
+An image object represents an image. It extends the BodyJson object with the
+following additional fields:
+
+| Attribute | Type     | Description                 |
+|-----------|----------|-----------------------------|
+| type      | string   | must be "img".              |
+| src       | string   | Optional HTTP(S) image URL. |
+| alt       | string   | Optional alternate text.    |
+| title     | string   | Optional image title.       |
+
+Due to the lack of image capabilities in Minecraft chat, an image is expected
+to be presented to Minecraft players as a link to the image source URL, using
+the alt text (or the title if no alt text is provided, or just "image" if
+neither alt or title are provided). If a title is provided it can be shown as a
+hover text.
+
+### BodyBlock Object:
+A block object represents a block of text with aligned lines. It extends the
+BodyJson object with the following additional fields, but may have more fields
+depending on the block identifier:
+
+| Attribute | Type     | Description                     |
+|-----------|----------|---------------------------------|
+| type      | string   | must be "block".                |
+| content   | BodyJson | Content contained in the block. |
+| block     | string   | A block identifier.             |
+
+### BodyBlockQuote Object:
+A block quote object represents a block of quoted text. It extends the
+BodyBlock object with the following additional fields:
+
+| Attribute | Type   | Description      |
+|-----------|--------|------------------|
+| block     | string | must be "quote". |
+
+It should present the content indented with a coloured line down the left, or
+with a prefix on each line such as "> ".
+
+### BodyBlockBullet Object:
+A bullet block object represents a bullet point followed by block of text with
+aligned lines. It extends the BodyBlock object with the following additional
+fields:
+
+| Attribute | Type    | Description             |
+|-----------|---------|-------------------------|
+| block     | string  | must be "bullet".       |
+| n         | integer | Optional bullet number. |
+
+The bullet presented may vary depending on the depth of bullet point nesting.
+
+If n is present the bullet is a numbered point. Similarly to unnumbered bullets
+the type of numbering may vary (between decimal, roman, and alphanumeric
+numbering) depending on the depth of bullet point nesting.
+
+### BodyBlockInline Object:
+An inline block object represents a block of text with aligned lines that may
+start after and on the same line as other text. It extends the BodyBlock object
+with the following additional fields:
+
+| Attribute | Type   | Description       |
+|-----------|--------|-------------------|
+| block     | string | must be "inline". |
+
+### BodyHorizontalRule Object:
+A horizontal rule object represents a horizontal line to the end of the line.
+It extends the BodyJson object with the following additional fields:
+
+| Attribute | Type   | Description               |
+|-----------|--------|---------------------------|
+| type      | string | must be "horizontalRule". |
+
+It should ideally be presented as a gray horizontal line to the end of the
+line, but doesn't have to go all the way.
+
+Consider the use of hyphens and strike-through to present the line via text
+chat and to the game console.

--- a/docs/Classes.md
+++ b/docs/Classes.md
@@ -78,14 +78,14 @@ Minecraft chat.
 This stores all new Matrix messages in memory for a Minecraft server to come
 and retrieve (see Main.getNewMxMessages)
 
-#### getRoomMember(): any
+#### getUserProfile(): MatrixProfile
 | Parameter | Type   | Description                                |
 |-----------|--------|--------------------------------------------|
+| user      | string | The user profile being retrieved           |
 | room      | string | The room to retrieve the profile data from |
-| user      | string | The user being retrieved                   |
 
-This gets the [`m.room.member` state event](https://matrix.org/docs/spec/client_server/r0.6.1#m-room-member) 
-of a given user in a given room. This is a utility method.
+This gets the cached profile of a provided Matrix ID in a room. This is a
+utility method.
 
 #### onMxMessage(): Promise\<void>
 | Parameter | Type   | Description                     |

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -63,39 +63,53 @@ likes, for example showing the displayName but with the MXID in a tooltip.
 This describes a normal text message send by the Matrix sender user. It extends
 the MxEvent object with the following additional fields:
 
-| Attribute | Type   | Description             |
-|-----------|--------|-------------------------|
-| type      | string | must be "message.text". |
-| body      | string | The message itself.     |
+| Attribute | Type     | Description                            |
+|-----------|----------|----------------------------------------|
+| type      | string   | must be "message.text".                |
+| body      | string   | The message itself.                    |
+| bodyJson  | BodyJson | Optional formatted version of message. |
 
 The Minecraft plugin is expected to broadcast the message, prefixing the body
-with the name of the sender.
+(or bodyJson if formatting is supported) with the name of the sender.
+
+See [Message Body JSON Format](./BodyJson.md) for details about the
+interpretation of bodyJson.
 
 ##### message.emote Event:
 This describes an emote message send by the Matrix sender user (e.g. with
 "/me").
 It extends the MxEvent object with the following additional fields:
 
-| Attribute | Type   | Description              |
-|-----------|--------|--------------------------|
-| type      | string | must be "message.emote". |
-| body      | string | The message itself.      |
+| Attribute | Type     | Description                            |
+|-----------|----------|----------------------------------------|
+| type      | string   | must be "message.emote".               |
+| body      | string   | The message itself.                    |
+| bodyJson  | BodyJson | Optional formatted version of message. |
 
 The Minecraft plugin is expected to broadcast the message, prefixing the body
-with e.g. "\*" and the name of the sender.
+(or bodyJson if formatting is supported) with e.g. "\*" and the name of the
+sender.
+
+See [Message Body JSON Format](./BodyJson.md) for details about the
+interpretation of bodyJson.
 
 ##### message.announce Event:
 This describes an announcement message send by a sufficiently privileged Matrix
 sender user (i.e. with "!minecraft announce").
 It extends the MxEvent object with the following additional fields:
 
-| Attribute | Type   | Description                 |
-|-----------|--------|-----------------------------|
-| type      | string | must be "message.announce". |
-| body      | string | The message itself.         |
+| Attribute | Type     | Description                            |
+|-----------|----------|----------------------------------------|
+| type      | string   | must be "message.announce".            |
+| body      | string   | The message itself.                    |
+| bodyJson  | BodyJson | Optional formatted version of message. |
 
 The Minecraft plugin is expected to broadcast the message as if send from the
-Minecraft server console, e.g. prefixing the body with "[Server] ".
+Minecraft server console, e.g. prefixing the body (or bodyJson if formatting is
+supported) with "[Server] ".
+
+See [Message Body JSON Format](./BodyJson.md) for details about the
+interpretation of bodyJson.
 
 ##### player.kick Event:
 This describes the kicking of a Minecraft user from the Matrix room.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,6 @@ Join our Matrix room for discussions!
  will utilize the extra classes to add features.
  2. [Endpoints](./Endpoints.md) These are all the HTTP endpoints that are
  opened by the WebInterface class.
+ 3. [Message Body JSON Format](./BodyJson.md) This is the intermediate JSON
+ format used to represent formatted Matrix message bodies.
 

--- a/src/matrix/MatrixInterface.ts
+++ b/src/matrix/MatrixInterface.ts
@@ -43,7 +43,7 @@ export class MatrixInterface {
     let registration = RegManager.getRegistration(config);
 
     this.main = marco;
-    this.msgProcessor = new MsgProcessor(this);
+    this.msgProcessor = new MsgProcessor(this, config);
     this.appservice = new matrix.Appservice({
       registration,
       bindAddress: config.appservice.bindAddress,
@@ -387,7 +387,33 @@ export class MatrixInterface {
    * @returns {string}
    */
   public getPlayerUUID(user: string): string | undefined {
+    // The bot mxid looks a bit like a player mxid
+    if (user == this.appservice.botUserId)
+      return undefined;
     return this.appservice.getSuffixForUserId(user);
+  }
+
+  /**
+   * This checks if the user has a power level sufficient for room notifications
+   * @param {string} roomId Room to check
+   * @param {string} userId User checking
+   * @returns {Promise<boolean>}
+   */
+  public async checkRoomNotifyPrivilege(roomId: string, userId: string): Promise<boolean> {
+    const client = this.appservice.botClient;
+    const powerLevels = await client.getRoomStateEvent(roomId, 'm.room.power_levels', '');
+    if (!powerLevels)
+      return false;
+
+    let requiredPower = 50;
+    if (powerLevels['notifications'] && powerLevels['notifications']['room'])
+      requiredPower = powerLevels['notifications']['room'];
+
+    let userPower = 0;
+    if (powerLevels['users'] && powerLevels['users'][userId])
+      userPower = powerLevels['users'][userId];
+
+    return userPower >= requiredPower;
   }
 
   /**

--- a/src/matrix/MatrixInterface.ts
+++ b/src/matrix/MatrixInterface.ts
@@ -73,6 +73,141 @@ export class MatrixInterface {
   }
 
   /**
+   * Escape plain text for use in HTML.
+   * This replace &, <, >, ', and " with the corresponding HTML entities.
+   * @param {string} text The plain text to escape
+   * @returns {string} HTML escaped version of plain text
+   */
+  public htmlEscape(text: string): string
+  {
+    const replacement: { [key: string]: string } = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&apos;',
+    };
+    return text.replace(/[&<>"']/g, function(ent: string): string {
+      return replacement[ent] || ent;
+    });
+  }
+
+  /**
+   * This intakes a Minecraft chat message and formats it as a matrix message.
+   * Implemented with help from https://minecraft.gamepedia.com/Formatting_codes
+   * @param {MCEvents.Message} mcMessage
+   * @returns {any} Matrix m.room.message content
+   */
+  public formatMcMessage(mcMessage: MCEvents.Message): any {
+    let content: {msgtype:string,body:string,format?:string,formatted_body?:string} = {
+      msgtype: "m.text",
+      body: mcMessage.message,
+    };
+    // Interpret and strip any Minecraft formatting codes from the body,
+    // producing corresponding Matrix HTML for it if necessary.
+    let useFormatting: boolean = false;
+    let formatted = '';
+    let body = '';
+    let tags: string[] = [];
+    let pendingTags: string[] = [];
+    let pendingTagsStr: string = '';
+    const regex = /(\u00a7(.))?([^\u00a7]*)/g;
+    const matches = content.body.matchAll(regex);
+    for (const match of matches) {
+      let fmt = match[2];
+      const lit = match[3];
+      if (fmt) {
+        let colourCode;
+        let htmlTag;
+        let reset: boolean = false;
+        fmt = fmt.toLowerCase();
+        switch (fmt) {
+          // Colour codes
+          case '0': case '1': case '2': case '3':
+          case '4': case '5': case '6': case '7':
+          case '8': case '9': {
+            colourCode = fmt.charCodeAt(0) - '0'.charCodeAt(0);
+            break;
+          }
+          case 'a': case 'b':
+          case 'c': case 'd': case 'e': case 'f': {
+            colourCode = 0xa + fmt.charCodeAt(0) - 'a'.charCodeAt(0);
+            break;
+          }
+
+          // Formatting codes
+          case 'l': htmlTag = 'b';      break; // bold
+          case 'm': htmlTag = 'strike'; break; // strikethrough
+          case 'n': htmlTag = 'u';      break; // underline
+          case 'o': htmlTag = 'i';      break; // italic
+
+          // Reset code
+          case 'r': reset = true; break;
+        }
+
+        if (colourCode !== undefined) {
+          let col = 0x000000;
+          if (colourCode & 0x1) // blue
+            col |= 0x0000AA;
+          if (colourCode & 0x2) // green
+            col |= 0x00AA00;
+          if (colourCode & 0x4) // red
+            col |= 0xAA0000;
+          if (colourCode & 0x8) // light
+            col |= 0x555555;
+          if (colourCode == 6) // gold
+            col |= 0xff0000;
+
+          // Close any open tags (Java Edition only)
+          while (tags.length) {
+            let tag = tags.pop();
+            formatted += `</${tag}>`
+          }
+          pendingTags = ['font'];
+          pendingTagsStr = `<font color="#${col.toString(16).padStart(6, '0')}">`;
+        } else if (htmlTag) {
+          if (pendingTags.indexOf(htmlTag) == -1 ||
+              tags.indexOf(htmlTag) == -1) {
+            pendingTags.push(htmlTag);
+            pendingTagsStr += `<${htmlTag}>`
+          }
+        } else if (reset) {
+          // Close any open tags
+          pendingTags = [];
+          pendingTagsStr = '';
+          while (tags.length) {
+            let tag = tags.pop();
+            formatted += `</${tag}>`
+          }
+        }
+      }
+      if (lit) {
+        // Handle lazy tags
+        formatted += pendingTagsStr;
+        tags = tags.concat(pendingTags);
+        pendingTags = [];
+        pendingTagsStr = '';
+
+        if (tags.length)
+          useFormatting = true;
+        formatted += this.htmlEscape(lit);
+        body += lit;
+      }
+    }
+    content.body = body;
+    if (useFormatting) {
+      // Close any open tags
+      while (tags.length) {
+        let tag = tags.pop();
+        formatted += `</${tag}>`
+      }
+      content.format = 'org.matrix.custom.html';
+      content.formatted_body = formatted;
+    }
+    return content;
+  }
+
+  /**
    * This intakes a Minecraft chat message and relays it the provided bridged
    * room.
    * @param {Bridge} bridge
@@ -105,9 +240,9 @@ export class MatrixInterface {
       LogService.error('marco-matrix', errMessage);
     } finally {
       // what matters most is that the message gets to the room.
-      await intent.sendText(
+      await intent.sendEvent(
         bridge.room,
-        mcMessage.message
+        this.formatMcMessage(mcMessage)
       );
     }
   }

--- a/src/matrix/internal/MsgProcessor.ts
+++ b/src/matrix/internal/MsgProcessor.ts
@@ -1,3 +1,4 @@
+import { MatrixProfile } from "matrix-bot-sdk";
 import { MatrixInterface, MxMessage } from "../MatrixInterface";
 import { MxEvents } from "../../minecraft";
 import { Player } from "../../minecraft/internal/Player";
@@ -17,8 +18,8 @@ export class MsgProcessor {
     const content = event['content'];
     const sender = event['sender'];
     const body = content['body'];
-    const roomMember = await this.matrix.getRoomMember(room, sender);
-    const name: string = roomMember['displayname'] || sender;
+    const senderProfile = await this.matrix.getUserProfile(sender, room);
+    const name: string = senderProfile.displayName;
 
     return {
       sender: sender,
@@ -47,8 +48,8 @@ export class MsgProcessor {
     const content = event['content'];
     const sender = event['sender'];
     const body = content['body'];
-    const roomMember = await this.matrix.getRoomMember(room, sender);
-    const name: string = roomMember['displayname'] || sender;
+    const senderProfile = await this.matrix.getUserProfile(sender, room);
+    const name: string = senderProfile.displayName;
 
     return {
       sender: sender,
@@ -72,9 +73,9 @@ export class MsgProcessor {
     const sender = event['sender'];
     const victim = event['state_key'];
 
-    const senderRoomMember = await this.matrix.getRoomMember(room, sender);
+    const senderProfile = await this.matrix.getUserProfile(sender, room);
     const victimUUID: string | undefined = this.matrix.getPlayerUUID(victim);
-    const senderName: string = senderRoomMember['displayname'] || sender;
+    const senderName: string = senderProfile.displayName;
     const victimName: string = prevContent['displayname'] || victimUUID;
 
     return {
@@ -99,9 +100,9 @@ export class MsgProcessor {
     const sender = event['sender'];
     const victim = event['state_key'];
 
-    const senderRoomMember = await this.matrix.getRoomMember(room, sender);
+    const senderProfile = await this.matrix.getUserProfile(sender, room);
     const victimUUID: string | undefined = this.matrix.getPlayerUUID(victim);
-    const senderName: string = senderRoomMember['displayname'] || sender;
+    const senderName: string = senderProfile.displayName;
     const victimName: string = prevContent['displayname'] || victimUUID;
 
     return {
@@ -124,9 +125,9 @@ export class MsgProcessor {
     const sender = event['sender'];
     const victim = event['state_key'];
 
-    const senderRoomMember = await this.matrix.getRoomMember(room, sender);
+    const senderProfile = await this.matrix.getUserProfile(sender, room);
     const victimUUID: string | undefined = this.matrix.getPlayerUUID(victim);
-    const senderName: string = senderRoomMember['displayname'] || sender;
+    const senderName: string = senderProfile.displayName;
     const victimName: string = prevContent['displayname'] || victimUUID;
 
     return {

--- a/src/matrix/internal/MsgProcessor.ts
+++ b/src/matrix/internal/MsgProcessor.ts
@@ -2,9 +2,590 @@ import { MatrixProfile } from "matrix-bot-sdk";
 import { MatrixInterface, MxMessage } from "../MatrixInterface";
 import { MxEvents } from "../../minecraft";
 import { Player } from "../../minecraft/internal/Player";
+import { Config } from "../../Config";
 
 export class MsgProcessor {
-  constructor(private readonly matrix: MatrixInterface) {}
+  constructor(private readonly matrix: MatrixInterface, private readonly config: Config)
+  {
+  }
+
+  /**
+   * Decode HTML entities into plain text.
+   * This replace &amp;, &lt;, &gt;, &apos;, and &quot; with the corresponding
+   * plain text characters.
+   * @param {string} html HTML
+   * @returns {string} The plain text equivalent
+   */
+  public htmlDecode(text: string): string
+  {
+    // FIXME Need more cases here??
+    const replacement: { [key: string]: string } = {
+      '&amp;': '&',
+      '&lt;': '<',
+      '&gt;': '>',
+      '&quot;': '"',
+      '&apos;': "'",
+      '&nbsp;': " ",
+    };
+    return text.replace(/&(\w+);/g, function(ent: string): string {
+      return replacement[ent] || ent;
+    });
+  }
+
+  /**
+   * Parse an HTML colour code into a 24bit colour value.
+   * @param {string} text HTML colour in the form "#rrggbb" or "#rgb"
+   * @returns {number|null} parsed 24-bit colour value (0xRRGGBB)
+   */
+  public htmlColorTo24bit(text: string): number | null
+  {
+    // Validate
+    const match = text.match(/^#([0-9a-fA-F]+)$/);
+    if (!match)
+      return null;
+
+    // Should be 3 or 6 nibbles
+    let hex = match[1];
+    if (hex.length == 3) {
+      // Expand to 6 nibbles
+      hex = hex.charAt(0) + hex.charAt(0) 
+          + hex.charAt(1) + hex.charAt(1)
+          + hex.charAt(2) + hex.charAt(2);
+    } else if (hex.length != 6) {
+      return null;
+    }
+
+    // Parse
+    const parsed = parseInt(hex, 16);
+    if (isNaN(parsed))
+      return null;
+
+    return parsed;
+  }
+
+  public simplifyBodyJson(jsonPrep: MxEvents.BodyStructPrep) {
+    let json = jsonPrep as MxEvents.BodyStruct;
+    for (let i = 0; i < jsonPrep.content.length; ++i) {
+      let item = jsonPrep.content[i];
+      if (typeof item === "string") {
+        if (i > 0) {
+          let lastItem = jsonPrep.content[i-1];
+          // Merge consecutive strings
+          if (typeof lastItem === "string") {
+            jsonPrep.content[i-1] = lastItem.concat(item);
+            jsonPrep.content.splice(i, 1);
+            --i;
+            continue;
+          }
+        }
+      } else {
+        if (item._erase === false) {
+          // Drop _erase:false tag
+          delete item._erase;
+        } else if (!item.content) {
+          // Remove erasable content
+          jsonPrep.content.splice(i, 1);
+          --i;
+          continue;
+        }
+      }
+    }
+    if (jsonPrep.content.length == 1) {
+      json.content = jsonPrep.content[0];
+    }
+  }
+
+  /**
+   * This takes a message string and appends it to the bodyJson content taking
+   * care to extract room mentions.
+   * @param {string} str Raw message string
+   * @param {MxEvents.BodyStructPrep} bodyJson JSON object to add to
+   * @param {boolean} force Whether to force output even for a single string
+   */
+  private extractRoomMentions(str: string, bodyJson: MxEvents.BodyStructPrep, force: boolean) {
+    // Transform @room into a room mention
+    const atRoomRegex = /@room\b/g;
+    const items = str.split(atRoomRegex);
+    if (!force && items.length <= 1)
+      return;
+
+    let mention: MxEvents.BodyMention = {
+      type: "mention",
+      room: true,
+      content: [ "@room" ],
+    };
+
+    if (items[0])
+      bodyJson.content.push(items[0]);
+    for (let i: number = 1; i < items.length; ++i) {
+      bodyJson.content.push(mention);
+      if (items[i])
+        bodyJson.content.push(items[i]);
+    }
+  }
+
+  /**
+   * This intakes the content of a Matrix chat message and formats it as a
+   * Minecraft message, using formatting codes.
+   * Implemented with help from https://minecraft.gamepedia.com/Formatting_codes
+   * @param {any} event Matrix m.room.message event
+   * @returns {string} Message body
+   */
+  public async formatMxMessage(event: any): Promise<[string, MxEvents.BodyJson?]> {
+    const content = event['content'];
+    const sender: string = event['sender'];
+    const roomId: string = event['room_id'];
+    const format: string = content['format'];
+    const formattedBody: string = content['formatted_body'];
+
+    // Unformatted body, stripping out any Minecraft formatting code characters
+    let body: string = content['body'].replace(/\u00a7/g, '');
+    let bodyJson: MxEvents.BodyStructPrep = {type:"", content:[]};
+
+    // Check for a room mention in body
+    let allowRoomMention: Promise<boolean>;
+    if (body.match(/@room\b/)) {
+      // We should only allow if the user has sufficient power in this room
+      allowRoomMention = this.matrix.checkRoomNotifyPrivilege(roomId, sender);
+    } else {
+      // Disallow
+      allowRoomMention = new Promise((resolve, reject) => { resolve(false); });
+    }
+
+    if (format == 'org.matrix.custom.html') {
+      // Convert the HTML to Minecraft 
+      // Detect tags and plain text in between
+      const tagRegex = /(\s*)(<(\/)?([\w-]+)(\s+([^>]*))?\s*(\/)?>)?(\s*)([^<]*[^<\s])?/g;
+      const attrRegex = /\s*([\w-]+)(="([^"]*)")?/g;
+      const matches = formattedBody.matchAll(tagRegex);
+      let tagStack: {
+        tag: string,
+        endBlock?: boolean,
+        json?: MxEvents.BodyStructPrep,
+        nextBullet: number | null
+      }[] = [];
+      let curJson: MxEvents.BodyStructPrep = bodyJson;
+      let blockDirty: boolean = false; // block is dirty (non empty, needing newline)
+      let endBlock: boolean = false; // block end is pending
+      let nextBullet: number | null = null;
+      for (const match of matches) {
+        let preWhitespace = match[1];
+        let tagClose = match[3];
+        let tag = match[4];
+        let tagAttrs = match[6];
+        let tagNoOpen = match[7];
+        let postWhitespace = match[8];
+        let lit = match[9];
+        let json: MxEvents.BodyStruct | undefined;
+        let nextBlockDirty: boolean = false; // whether new block starts dirty
+        let preWhitespaceEmitted: boolean = false;
+        if (tag) {
+          tag = tag.toLowerCase();
+          if (tagClose) {
+            // Look back on the tagStack for a tag to close
+            let thisEndBlock: boolean = false;
+            let thisLastJson: MxEvents.BodyStructPrep = curJson;
+            for (let i = tagStack.length-1; i >= 0; --i) {
+              if (tagStack[i].endBlock)
+                thisEndBlock = true;
+              let thisJson = tagStack[i].json;
+              if (thisJson !== undefined)
+                thisLastJson = thisJson;
+              // Match tag name
+              if (tagStack[i].tag == tag) {
+                if (thisEndBlock) {
+                  endBlock = true;
+                  // Discard inter-element whitespace before and after a block close tag
+                  preWhitespace = "";
+                  postWhitespace = "";
+                }
+                if (preWhitespace) {
+                  curJson.content.push(" ");
+                  preWhitespaceEmitted = true;
+                }
+                if (curJson !== thisLastJson) {
+                  this.simplifyBodyJson(curJson);
+                  for (let j = tagStack.length-1; j >= i; --j) {
+                    let jsonPrep = tagStack[j].json;
+                    if (jsonPrep && jsonPrep !== thisLastJson) {
+                      this.simplifyBodyJson(jsonPrep);
+                    }
+                  }
+                  curJson = thisLastJson;
+                }
+                nextBullet = tagStack[i].nextBullet;
+                // Drop this and later entries from stack
+                tagStack = tagStack.slice(0, i);
+                break;
+              }
+            }
+          } else {
+            // Extract attributes
+            let attrs: {[key: string]: string} = {};
+            if (tagAttrs) {
+              const attrMatches = tagAttrs.matchAll(attrRegex);
+              for (const attrMatch of attrMatches) {
+                const attr = attrMatch[1].toLowerCase();
+                let val = attrMatch[3];
+                if (val) {
+                  // Sanitise attributes, including reducing whitespace and
+                  // stripping Minecraft formatting codes characters.
+                  val = val.replace(/\s+/g, ' ');
+                  val = this.htmlDecode(val);
+                  val = val.replace(/\u00a7/g, '');
+                } else {
+                  val = attr;
+                }
+                attrs[attr] = val;
+              }
+            }
+            let isBlock: boolean = false;
+            let forceEndBlock: boolean = false; // force ending of block (<br />)
+            switch (tag) {
+              case 'font':
+              case 'span': {
+                for (let attr of [ 'data-mx-color', 'color' ]) {
+                  if (attrs[attr]) {
+                    let parsed = this.htmlColorTo24bit(attrs[attr]);
+                    if (parsed !== null) {
+                      let style: MxEvents.BodyStyle = {
+                        type: "style",
+                        color: parsed,
+                        content: [],
+                      };
+                      json = style;
+                      break;
+                    }
+                  }
+                }
+                if (attrs['data-mx-spoiler']) {
+                  let style: MxEvents.BodyStyle = {
+                    type: "style",
+                    spoiler: true,
+                    content: [],
+                  };
+                  json = style;
+                }
+                break;
+              }
+
+              case 'del':
+              case 'strike': {
+                let style: MxEvents.BodyStyle = {
+                  type: "style",
+                  strike: true,
+                  content: [],
+                };
+                json = style;
+                break;
+              }
+
+              case 'h1':
+              case 'h2':
+              case 'h3':
+              case 'h4':
+              case 'h5':
+              case 'h6': {
+                let style: MxEvents.BodyStyle = {
+                  type: "style",
+                  heading: parseInt(tag.substr(1)),
+                  content: [],
+                };
+                json = style;
+                isBlock = true;
+                break;
+              }
+
+              case 'ul': {
+                nextBullet = null;
+                isBlock = true;
+                break;
+              }
+              case 'ol': {
+                nextBullet = 1;
+                if (attrs['start']) {
+                  const start = parseInt(attrs['start']);
+                  if (!isNaN(start))
+                    nextBullet = start;
+                }
+                isBlock = true;
+                break;
+              }
+              case 'li': {
+                let bullet: MxEvents.BodyBlockBullet = {
+                  type: "block",
+                  block: "bullet",
+                  content: [],
+                };
+                if (nextBullet !== null)
+                  bullet['n'] = nextBullet++;
+                json = bullet;
+                isBlock = true;
+                break;
+              }
+              case 'p':
+              case 'div':
+              case 'table':
+              case 'tr':
+              case 'pre': {
+                isBlock = true;
+                break;
+              }
+
+              case 'hr': {
+                let hr: MxEvents.BodyHorizontalRule = {
+                  type: "horizontalRule",
+                  _erase: false,
+                };
+                json = hr;
+                isBlock = true;
+                nextBlockDirty = true; // even though no content
+                tagNoOpen = '/';
+                break;
+              }
+
+              case 'blockquote': {
+                let quote: MxEvents.BodyBlockQuote = {
+                  type: "block",
+                  block: "quote",
+                  content: [],
+                };
+                json = quote;
+                isBlock = true;
+                break;
+              }
+
+              case 'a': {
+                // name, target, href (https, http, ftp, mailto, magnet)
+                // start
+                if (attrs['href']) {
+                  let match = attrs['href'].match(/^https:\/\/matrix\.to\/#\/(@[^:]+:.*)$/);
+                  if (match) {
+                    let mxid: string = match[1];
+                    let profile: MatrixProfile = await this.matrix.getUserProfile(mxid, roomId);
+                    let mention: MxEvents.BodyMention = {
+                      type: "mention",
+                      user: {
+                        mxid: mxid,
+                        displayName: profile.displayName,
+                      },
+                      content: [],
+                    };
+                    json = mention;
+
+                    // Is it a Minecraft player!
+                    let uuid = this.matrix.getPlayerUUID(mxid);
+                    if (uuid) {
+                      let mcMention: MxEvents.BodyMentionMinecraft = mention as MxEvents.BodyMentionMinecraft;
+                      mcMention.bridge = "minecraft";
+                      mcMention.player = {
+                        uuid: uuid,
+                      };
+                    }
+                    break;
+                  }
+                  match = attrs['href'].match(/^([^:]+):/);
+                  if (match) {
+                    const protocols: {[x:string]:true} = {
+                      https: true,
+                      http: true,
+                      ftp: true,
+                      mailto: true,
+                      magnet: true,
+                    };
+                    if (protocols[match[1]]) {
+                      let link: MxEvents.BodyLink = {
+                        type: "link",
+                        href: attrs['href'],
+                        content: [],
+                      };
+                      json = link;
+                    }
+                  }
+                }
+                break;
+              }
+              case 'sup':
+              case 'sub':
+                break;
+
+              case 'b':
+              case 'strong': {
+                let style: MxEvents.BodyStyle = {
+                  type: "style",
+                  bold: true,
+                  content: [],
+                };
+                json = style;
+                break;
+              }
+
+              case 'i':
+              case 'em': {
+                let style: MxEvents.BodyStyle = {
+                  type: "style",
+                  italic: true,
+                  content: [],
+                };
+                json = style;
+                break;
+              }
+
+              case 'u': {
+                let style: MxEvents.BodyStyle = {
+                  type: "style",
+                  underline: true,
+                  content: [],
+                };
+                json = style;
+                break;
+              }
+
+              case 'code':
+                // class (language-*)
+                let style: MxEvents.BodyStyle = {
+                  type: "style",
+                  code: true,
+                  content: [],
+                };
+                json = style;
+                break;
+
+              case 'br': {
+                isBlock = true;
+                // force newline
+                forceEndBlock = true;
+                // even if block is clean
+                blockDirty = true;
+                tagNoOpen = '/';
+                break;
+              }
+              case 'thead':
+              case 'tbody':
+              case 'th':
+              case 'td':
+              case 'caption':
+                break;
+
+              case 'img': {
+                // width, height, alt, title, src
+                let img: MxEvents.BodyImg = {
+                  type: "img",
+                  _erase: false,
+                };
+                if (attrs['title'])
+                  img.title = attrs['title'];
+                if (attrs['alt'])
+                  img.alt = attrs['alt'];
+                // Validate src
+                if (attrs['src']) {
+                  let match = attrs['src'].match(/^mxc:\/\/([^\/#?]+)\/([^\/#?]+)$/);
+                  if (match)
+                    img.src = `${this.config.appservice.homeserverURL}/_matrix/media/r0/download/${match[1]}/${match[2]}`;
+                }
+                json = img;
+                tagNoOpen = '/';
+                break;
+              }
+
+              default:
+                break;
+            }
+            if (isBlock) {
+              // End previous block before starting a new one
+              endBlock = true;
+              // Discard inter-element whitespace before and after a block tag
+              preWhitespace = "";
+              postWhitespace = "";
+            }
+            // Open new block: push onto tag stack
+            if (!tagNoOpen) {
+              tagStack.push({
+                tag:tag,
+                endBlock: isBlock,
+                json: json ? curJson : undefined,
+                nextBullet: nextBullet,
+              });
+            }
+
+            if (preWhitespace) {
+              curJson.content.push(" ");
+              preWhitespaceEmitted = true;
+            }
+
+            if (json || forceEndBlock) {
+              // End a previous dirty block on new content
+              if (endBlock) {
+                endBlock = false;
+                if (blockDirty)
+                  curJson.content.push("\n");
+                blockDirty = nextBlockDirty;
+                nextBlockDirty = false;
+              }
+            }
+            if (json) {
+              curJson.content.push(json);
+              if (!tagNoOpen) {
+                // json should only get set with array content
+                curJson = json as MxEvents.BodyStructPrep;
+              }
+            }
+            if (isBlock && tagNoOpen)
+              endBlock = true;
+          }
+        }
+
+        // Emit adjacent whitespace
+        if ((preWhitespace || postWhitespace) && !preWhitespaceEmitted)
+          curJson.content.push(" ");
+
+        if (lit) {
+          // Reduce whitespace including newlines
+          lit = lit.replace(/[\s]+/g, ' ');
+          // Decode HTML entities...
+          lit = this.htmlDecode(lit);
+          // ... and strip out Minecraft formatting code characters
+          lit = lit.replace(/\u00a7/g, '');
+
+          if (lit) {
+            // End a previous dirty block on new content
+            if (endBlock) {
+              endBlock = false;
+              if (blockDirty) {
+                curJson.content.push("\n");
+                blockDirty = false;
+              }
+            }
+            if (lit) {
+              blockDirty = true;
+              if (await allowRoomMention)
+                this.extractRoomMentions(lit, curJson, true);
+              else
+                curJson.content.push(lit);
+            }
+          }
+        }
+      }
+
+      // Clean up json
+      for (let i = tagStack.length-1; i >= 0; --i) {
+        let jsonPrep = tagStack[i].json;
+        if (jsonPrep)
+          this.simplifyBodyJson(jsonPrep);
+      }
+      this.simplifyBodyJson(curJson);
+
+    } else if (await allowRoomMention) {
+      this.extractRoomMentions(body, bodyJson, false);
+    }
+
+    if (bodyJson.content.length !== 0) {
+      // Use formatted body
+      return [body, bodyJson.content as MxEvents.BodyJson];
+    } else {
+      return [body];
+    }
+  }
 
   /**
    * This intakes an m.emote message type and builds to be ready to be sent
@@ -15,11 +596,11 @@ export class MsgProcessor {
    * @returns {Promise<string>}
    */
   public async buildEmoteMsg(room: string, event: any): Promise<MxMessage> {
-    const content = event['content'];
     const sender = event['sender'];
-    const body = content['body'];
+    const bodies = this.formatMxMessage(event);
     const senderProfile = await this.matrix.getUserProfile(sender, room);
     const name: string = senderProfile.displayName;
+    const [body, bodyJson] = await bodies;
 
     return {
       sender: sender,
@@ -32,6 +613,7 @@ export class MsgProcessor {
         },
         type: "message.emote",
         body: body,
+        bodyJson: bodyJson,
       } as MxEvents.Event
     };
   }
@@ -45,11 +627,11 @@ export class MsgProcessor {
    * @returns {Promise<string>}
    */
   public async buildTextMsg(room: string, event: any): Promise<MxMessage> {
-    const content = event['content'];
     const sender = event['sender'];
-    const body = content['body'];
+    const bodies = this.formatMxMessage(event);
     const senderProfile = await this.matrix.getUserProfile(sender, room);
     const name: string = senderProfile.displayName;
+    const [body, bodyJson] = await bodies;
 
     return {
       sender: sender,
@@ -62,6 +644,7 @@ export class MsgProcessor {
         },
         type: "message.text",
         body: body,
+        bodyJson: bodyJson,
       } as MxEvents.Event
     };
   }

--- a/src/minecraft/internal/types.ts
+++ b/src/minecraft/internal/types.ts
@@ -19,6 +19,80 @@ export module MxEvents {
     displayName: string;
   }
 
+  export type MinecraftPlayer = {
+    uuid: string;
+  };
+
+  export interface BodyStructRaw<Content> {
+    type: string;
+    content?: Content;
+    [x: string]: any;
+  }
+  export type BodyJson = string | BodyStructRaw<BodyJson> | (string | BodyStructRaw<BodyJson>)[];
+  export type BodyStruct = BodyStructRaw<BodyJson>;
+
+  type BodyJsonArray = (string | BodyStructRaw<BodyJson>)[];
+  export interface BodyStructPrep extends BodyStruct {
+    content: BodyJsonArray;
+    _erase?: false;
+  }
+
+  export interface BodySpan extends BodyStruct {
+    content: BodyJson;
+  }
+  export interface BodyStyle extends BodySpan {
+    type: "style";
+    color?: number;
+    bold?: true;
+    italic?: true;
+    underline?: true;
+    strike?: true;
+    spoiler?: true;
+    code?: true;
+    heading?: number;
+  }
+  export interface BodyLink extends BodySpan {
+    type: "link";
+    href: string;
+  }
+  export interface BodyMention extends BodySpan {
+    type: "mention";
+    room?: boolean;
+    user?: User;
+    bridge?: string;
+  }
+  export interface BodyMentionMinecraft extends BodyMention {
+    bridge: "minecraft";
+    player: MinecraftPlayer;
+  }
+  export interface BodyImg extends BodyStruct {
+    type: "img";
+    src?: string;
+    alt?: string;
+    title?: string;
+  }
+
+  export interface BodyBlock extends BodyStruct {
+    type: "block";
+    content: BodyJson;
+    block: string;
+  }
+  export interface BodyBlockQuote extends BodyBlock {
+    block: "quote";
+  }
+  export interface BodyBlockBullet extends BodyBlock {
+    block: "bullet";
+    n?: number;
+  }
+  export interface BodyBlockInline extends BodyBlock {
+    block: "inline";
+  }
+
+  export interface BodyHorizontalRule extends BodyStruct {
+    type: "horizontalRule";
+    content?: never;
+  }
+
   /**
    * This represents an event from Matrix that Minecraft needs to handle.
    * It is extended depending on the type string.
@@ -37,9 +111,11 @@ export module MxEvents {
    * It is further extended depending on the type string.
    * @type MessageEvent
    * @prop {string} body Message body
+   * @prop bodyJson JSON formatted message body
    */
   export interface MessageEvent extends Event {
     body: string;
+    bodyJson?: BodyJson;
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    /* Specify library files to be included in the compilation. */
+    "lib": ["es2020.string"],
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
These commits add support for converting of both minecraft text formatting codes and matrix HTML formatted messages.

There will be a corresponding PR matrix-plugin.

- We start by caching matrix profiles, which reduces profile requests to the homeserver (which are currently for every message, and would otherwise also be for every mention too after the later patches).
- Next we convert minecraft formatting codes to matrix HTML, which is fairly straightforward.
- For matrix->minecraft formatted messages we define & document an intermediate JSON format.
- Finally comes the slightly fiddly bit of interpreting the HTML and converting it into the intermediate format. This is done using regexes right now, which seems to work sufficiently for our purposes (using a dedicated library might be overkill for this tbh, but I'm open to opinions). A fairly significant subset of the matrix HTML is handled (but not tables, pre, sub/sup yet).