### PR TITLE
Skins & Nicks

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -151,13 +151,14 @@ The provided JSON web token describes what room the server is bridged with.
 | player    | Player | The player who sent the message       |
 
 ##### Player Object:
-This describes the player who sent the message, all the attributes must not
+This describes the player who sent the message, the name and uuid must not
 be null or undefined.
 
-| Attribute | Type   | Description            |
-|-----------|--------|------------------------|
-| name      | string | The name of the player |
-| uuid      | string | The UUID of the player |
+| Attribute   | Type   | Description                          |
+|-------------|--------|--------------------------------------|
+| name        | string | The name of the player               |
+| uuid        | string | The UUID of the player               |
+| texture     | string | Optional base64 encoded texture info |
 
 #### Response Body:
 None (200 OK)

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -158,6 +158,7 @@ be null or undefined.
 |-------------|--------|--------------------------------------|
 | name        | string | The name of the player               |
 | uuid        | string | The UUID of the player               |
+| displayName | string | Optional display name of the player  |
 | texture     | string | Optional base64 encoded texture info |
 
 #### Response Body:

--- a/src/minecraft/PlayerManager.ts
+++ b/src/minecraft/PlayerManager.ts
@@ -33,18 +33,21 @@ export class PlayerManager {
 
    * @param {?string} name Player's name
    * @param {?string} uuid Player's UUID
+   * @param {?string} texture Player's base64 encoded texture (skin)
    * @returns {Promise<void>}
    * @throws {Error} if both parameters are undefined
    */
-  public async getPlayer(name?: string, uuid?: string): Promise<Player> {
+  public async getPlayer(name?: string, uuid?: string, texture?: string): Promise<Player> {
     let player = this.players.get(uuid || '');
 
-    if (player)
+    if (player) {
+      if (texture)
+        player.setTexture(texture);
       return player;
-    else if (!name && !uuid)
+    } else if (!name && !uuid)
       throw new Error('Both parameters can not be undefined');
     else {
-      player = new Player(name, uuid);
+      player = new Player(name, uuid, texture);
       uuid = await player.getUUID();
       this.players.set(uuid, player);
       return player;

--- a/src/minecraft/PlayerManager.ts
+++ b/src/minecraft/PlayerManager.ts
@@ -33,21 +33,24 @@ export class PlayerManager {
 
    * @param {?string} name Player's name
    * @param {?string} uuid Player's UUID
+   * @param {?string} displayName Player's display name (nick)
    * @param {?string} texture Player's base64 encoded texture (skin)
    * @returns {Promise<void>}
    * @throws {Error} if both parameters are undefined
    */
-  public async getPlayer(name?: string, uuid?: string, texture?: string): Promise<Player> {
+  public async getPlayer(name?: string, uuid?: string, displayName?: string, texture?: string): Promise<Player> {
     let player = this.players.get(uuid || '');
 
     if (player) {
+      if (displayName)
+        player.setDisplayName(displayName);
       if (texture)
         player.setTexture(texture);
       return player;
     } else if (!name && !uuid)
       throw new Error('Both parameters can not be undefined');
     else {
-      player = new Player(name, uuid, texture);
+      player = new Player(name, uuid, displayName, texture);
       uuid = await player.getUUID();
       this.players.set(uuid, player);
       return player;
@@ -65,7 +68,7 @@ export class PlayerManager {
     const mxProfile = await intent.underlyingClient.getUserProfile(
       intent.userId
     );
-    const playerName = await player.getName();
+    const playerDisplayName = await player.getDisplayName();
     const mxName: string | undefined = mxProfile['displayname'];
     let storedSkin;
     try {
@@ -77,10 +80,16 @@ export class PlayerManager {
       storedSkin = '';
     }
 
+    LogService.debug(
+      'marco-PlayerManager',
+      `Player's current displayName:\n${playerDisplayName}\n` +
+      `Player's matrix displayName:\n${mxName}\n` +
+      `Difference? ${mxName == playerDisplayName ? 'no' : 'yes'}`
+    );
 
     // Sync display name with in-game player name
-    if (mxName != playerName) {
-      await intent.underlyingClient.setDisplayName(playerName);
+    if (mxName != playerDisplayName) {
+      await intent.underlyingClient.setDisplayName(playerDisplayName);
     }
 
     // Sync their Matrix's avatar with their in-game skin ...
@@ -108,6 +117,7 @@ export class PlayerManager {
 
       // This represents their new Matrix-content-url (mxc) which can be
       // used to set their Matrix user's avatar
+      const playerName = await player.getName();
       const mxUrl = await intent.underlyingClient.uploadContent(
         head,
         'image/png', // All skins are in PNG format

--- a/src/minecraft/internal/Player.ts
+++ b/src/minecraft/internal/Player.ts
@@ -12,10 +12,16 @@ import * as Endpoints from "./endpoints";
 export class Player {
   private name: string | null;
   private uuid: string | null;
+  private texture?: string;
 
-  public constructor(name?: string, uuid?: string) {
+  public constructor(name?: string, uuid?: string, texture?: string) {
     this.name = name || null;
     this.uuid = uuid || null;
+    this.texture = texture;
+  }
+
+  public setTexture(texture: string) {
+    this.texture = texture;
   }
 
   /**
@@ -92,6 +98,19 @@ export class Player {
     const uuid = await this.getUUID();
     const name = await this.getName();
     const target = Endpoints.get.profile.replace(/({uuid})/g, uuid);
+
+    // If we already have the texture, we can construct the profile without
+    // resorting to the Mojang API
+    if (this.texture) {
+      return {
+        'id': uuid,
+        'name': name,
+        'properties':  [ {
+          "name" : "textures",
+          "value" : this.texture
+        } ]
+      };
+    }
 
     try {
       return await getJSON(target);

--- a/src/minecraft/internal/Player.ts
+++ b/src/minecraft/internal/Player.ts
@@ -12,12 +12,18 @@ import * as Endpoints from "./endpoints";
 export class Player {
   private name: string | null;
   private uuid: string | null;
+  private displayName?: string;
   private texture?: string;
 
-  public constructor(name?: string, uuid?: string, texture?: string) {
+  public constructor(name?: string, uuid?: string, displayName?: string, texture?: string) {
     this.name = name || null;
     this.uuid = uuid || null;
+    this.displayName = displayName;
     this.texture = texture;
+  }
+
+  public setDisplayName(displayName: string) {
+    this.displayName = displayName;
   }
 
   public setTexture(texture: string) {
@@ -71,6 +77,17 @@ export class Player {
 
       return profile.name;
     }
+  }
+
+  /**
+   * This gets the display name chosen by the player.
+   * @returns {Promise<String>}
+   */
+  public async getDisplayName(): Promise<string> {
+    if (this.displayName != null)
+      return this.displayName;
+    else
+      return this.getName();
   }
 
   /**

--- a/src/webserver/internal/routes/chat/postChat.ts
+++ b/src/webserver/internal/routes/chat/postChat.ts
@@ -32,8 +32,8 @@ export async function postChat(req: Request, res: Response): Promise<void> {
   const id: string = req['id'];
   const body = req.body;
   const message: string = body['message'];
-  const playerRaw: { name: string, uuid: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
   const mcMessage: MCEvents.Message = {
     message,
     player

--- a/src/webserver/internal/routes/chat/postChat.ts
+++ b/src/webserver/internal/routes/chat/postChat.ts
@@ -32,8 +32,8 @@ export async function postChat(req: Request, res: Response): Promise<void> {
   const id: string = req['id'];
   const body = req.body;
   const message: string = body['message'];
-  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
+  const playerRaw: { name: string, uuid: string, displayName?: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.displayName, playerRaw.texture);
   const mcMessage: MCEvents.Message = {
     message,
     player

--- a/src/webserver/internal/routes/player/postJoin.ts
+++ b/src/webserver/internal/routes/player/postJoin.ts
@@ -27,8 +27,8 @@ export async function postJoin(req: Request, res: Response): Promise<void> {
   // @ts-ignore
   const id: string = req['id'];
   const body = req.body;
-  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
+  const playerRaw: { name: string, uuid: string, displayName?: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.displayName, playerRaw.texture);
   const mcJoin: MCEvents.Join = {
     player
   }

--- a/src/webserver/internal/routes/player/postJoin.ts
+++ b/src/webserver/internal/routes/player/postJoin.ts
@@ -27,8 +27,8 @@ export async function postJoin(req: Request, res: Response): Promise<void> {
   // @ts-ignore
   const id: string = req['id'];
   const body = req.body;
-  const playerRaw: { name: string, uuid: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
   const mcJoin: MCEvents.Join = {
     player
   }

--- a/src/webserver/internal/routes/player/postKick.ts
+++ b/src/webserver/internal/routes/player/postKick.ts
@@ -31,8 +31,8 @@ export async function postKick(req: Request, res: Response): Promise<void> {
   const id: string = req['id'];
   const body = req.body;
   const reason: string = body['reason'];
-  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
+  const playerRaw: { name: string, uuid: string, displayName?: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.displayName, playerRaw.texture);
   const mcKick: MCEvents.Kick = {
     reason,
     player

--- a/src/webserver/internal/routes/player/postKick.ts
+++ b/src/webserver/internal/routes/player/postKick.ts
@@ -31,8 +31,8 @@ export async function postKick(req: Request, res: Response): Promise<void> {
   const id: string = req['id'];
   const body = req.body;
   const reason: string = body['reason'];
-  const playerRaw: { name: string, uuid: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
   const mcKick: MCEvents.Kick = {
     reason,
     player

--- a/src/webserver/internal/routes/player/postQuit.ts
+++ b/src/webserver/internal/routes/player/postQuit.ts
@@ -27,8 +27,8 @@ export async function postQuit(req: Request, res: Response): Promise<void> {
   // @ts-ignore
   const id: string = req['id'];
   const body = req.body;
-  const playerRaw: { name: string, uuid: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid);
+  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
   const mcQuit: MCEvents.Quit = {
     player
   }

--- a/src/webserver/internal/routes/player/postQuit.ts
+++ b/src/webserver/internal/routes/player/postQuit.ts
@@ -27,8 +27,8 @@ export async function postQuit(req: Request, res: Response): Promise<void> {
   // @ts-ignore
   const id: string = req['id'];
   const body = req.body;
-  const playerRaw: { name: string, uuid: string, texture?: string } = body.player;
-  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.texture);
+  const playerRaw: { name: string, uuid: string, displayName?: string, texture?: string } = body.player;
+  const player = await main.players.getPlayer(playerRaw.name, playerRaw.uuid, playerRaw.displayName, playerRaw.texture);
   const mcQuit: MCEvents.Quit = {
     player
   }


### PR DESCRIPTION
These patches handle skin textures and nicknames from the plugin. Using the skin from the server avoids Mojang API calls and also works with offline mode servers or those using plugins such as SkinsRestorerX.

A corresponding PR will be opened for the plugin.

Closes #16